### PR TITLE
feat(pipeline): concurrency limit

### DIFF
--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -123,8 +123,8 @@ export class Shellable extends cdk.Construct {
     asset.grantRead(this.role);
   }
 
-  public addToPipeline(stage: cpipeline.Stage, name: string, inputArtifact: cpipelineapi.Artifact) {
-    this.project.addToPipeline(stage, name, { inputArtifact });
+  public addToPipeline(stage: cpipeline.Stage, name: string, inputArtifact: cpipelineapi.Artifact, runOrder?: number) {
+    this.project.addToPipeline(stage, name, { inputArtifact, runOrder });
   }
 }
 

--- a/lib/testable.ts
+++ b/lib/testable.ts
@@ -37,7 +37,7 @@ export class Testable extends cdk.Construct {
     this.project = this.shellable.project;
   }
 
-  public addToPipeline(stage: cpipeline.Stage, inputArtifact: cpipelineapi.Artifact) {
-    this.shellable.addToPipeline(stage, `Test${this.id}`, inputArtifact);
+  public addToPipeline(stage: cpipeline.Stage, inputArtifact: cpipelineapi.Artifact, runOrder?: number) {
+    this.shellable.addToPipeline(stage, `Test${this.id}`, inputArtifact, runOrder);
   }
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,0 +1,13 @@
+/**
+ * Determines the "RunOrder" property for the next action to be added to a stage.
+ * @param index Index of new action
+ * @param concurrency The concurrency limit
+ */
+export function determineRunOrder(index: number, concurrency?: number) {
+  // no runOrder if we are at unlimited concurrency
+  if (concurrency === undefined) {
+    return undefined;
+  }
+
+  return Math.floor(index / concurrency) + 1;
+}

--- a/pipeline/delivlib.ts
+++ b/pipeline/delivlib.ts
@@ -21,7 +21,7 @@ export class DelivLibPipelineStack extends cdk.Stack {
     const pipeline = new delivlib.Pipeline(this, 'GitHubPipeline', {
       title: 'aws-delivlib production pipeline',
       repo: github,
-      concurrency: false, // temporary until we increase the account limits
+      concurrency: 1, // temporary until we increase the account limits
       notificationEmail: 'aws-cdk-dev+delivlib-notify@amazon.com',
       buildSpec: {
         version: '0.2',

--- a/pipeline/delivlib.ts
+++ b/pipeline/delivlib.ts
@@ -21,6 +21,7 @@ export class DelivLibPipelineStack extends cdk.Stack {
     const pipeline = new delivlib.Pipeline(this, 'GitHubPipeline', {
       title: 'aws-delivlib production pipeline',
       repo: github,
+      concurrency: false, // temporary until we increase the account limits
       buildSpec: {
         version: '0.2',
         phases: {

--- a/test/expected.json
+++ b/test/expected.json
@@ -189,7 +189,7 @@ Resources:
               Name: TestHelloWindows
               OutputArtifacts:
                 - Name: Artifact_delivlibtestCodeCommitPipelineHelloWindowsTestHelloWindowsA5D9F16F
-              RunOrder: 1
+              RunOrder: 2
           Name: Test
         - Actions:
             - ActionTypeId:
@@ -219,7 +219,7 @@ Resources:
               Name: NuGetPublish
               OutputArtifacts:
                 - Name: Artifact_delivlibtestCodeCommitPipelineNuGetNuGetPublishD08C1873
-              RunOrder: 1
+              RunOrder: 2
             - ActionTypeId:
                 Category: Build
                 Owner: AWS
@@ -233,7 +233,7 @@ Resources:
               Name: MavenPublish
               OutputArtifacts:
                 - Name: Artifact_delivlibtestCodeCommitPipelineMavenMavenPublish23517E96
-              RunOrder: 1
+              RunOrder: 3
             - ActionTypeId:
                 Category: Build
                 Owner: AWS
@@ -247,7 +247,7 @@ Resources:
               Name: GitHubPublish
               OutputArtifacts:
                 - Name: Artifact_delivlibtestCodeCommitPipelineGitHubGitHubPublish9C2DACED
-              RunOrder: 1
+              RunOrder: 4
             - ActionTypeId:
                 Category: Build
                 Owner: AWS
@@ -261,7 +261,7 @@ Resources:
               Name: GitHubPagesPublish
               OutputArtifacts:
                 - Name: Artifact_delivlibtestCodeCommitPipelineGitHubPagesGitHubPagesPublishCDA7CDC1
-              RunOrder: 1
+              RunOrder: 5
           Name: Publish
       ArtifactStore:
         Location:
@@ -451,6 +451,58 @@ Resources:
         Type: CODEPIPELINE
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/BuildProject/Resource
+  CodeCommitPipelineBuildProjectOnBuildFailed2A08058D:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+          - aws.codebuild
+        detail-type:
+          - CodeBuild Build State Change
+        detail:
+          project-name:
+            - Ref: CodeCommitPipelineBuildProject9F59E8AA
+          build-status:
+            - FAILED
+      State: ENABLED
+      Targets:
+        - Arn:
+            Ref: CodeCommitPipelineNotificationsTopic36C2D667
+          Id: NotificationsTopic
+          InputTransformer:
+            InputTemplate: '"aws-delivlib test pipeline build failed"'
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/BuildProject/OnBuildFailed/Resource
+  CodeCommitPipelineNotificationsTopic36C2D667:
+    Type: AWS::SNS::Topic
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/NotificationsTopic/Resource
+  CodeCommitPipelineNotificationsTopicNotifyEmail146B339F:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: aws-cdk-dev+delivlib-test@amazon.com
+      Protocol: email
+      TopicArn:
+        Ref: CodeCommitPipelineNotificationsTopic36C2D667
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/NotificationsTopic/NotifyEmail/Resource
+  CodeCommitPipelineNotificationsTopicPolicyBBE90C33:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: sns:Publish
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Resource:
+              Ref: CodeCommitPipelineNotificationsTopic36C2D667
+            Sid: "0"
+        Version: "2012-10-17"
+      Topics:
+        - Ref: CodeCommitPipelineNotificationsTopic36C2D667
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/NotificationsTopic/Policy/Resource
   CodeCommitPipelinePipelineWatcherPollerServiceRole0A1D8005:
     Type: AWS::IAM::Role
     Properties:
@@ -630,42 +682,6 @@ Resources:
       TreatMissingData: ignore
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/PipelineWatcher/Alarm/Resource
-  CodeCommitPipelineDashboard6FF06F29:
-    Type: AWS::CloudWatch::Dashboard
-    Properties:
-      DashboardBody:
-        Fn::Join:
-          - ""
-          - - '{"widgets":[{"type":"text","width":24,"height":2,"x":0,"y":0,"properties":{"markdown":"#
-              aws-delivlib test pipeline Pipeline\n *
-              [Pipeline](https://console.aws.amazon.com/codepipeline/home?region='
-            - Ref: AWS::Region
-            - "#/view/"
-            - Ref: CodeCommitPipelineBuildPipeline656B8CCB
-            - )\n * [Build
-              History](https://console.aws.amazon.com/codebuild/home?region=
-            - Ref: AWS::Region
-            - "#/projects/"
-            - Ref: CodeCommitPipelineBuildProject9F59E8AA
-            - /view)\n"}},{"type":"metric","width":6,"height":6,"x":0,"y":2,"properties":{"view":"timeSeries","title":"Build
-              Duration","region":"
-            - Ref: AWS::Region
-            - '","metrics":[["AWS/CodeBuild","Duration","ProjectName","'
-            - Ref: CodeCommitPipelineBuildProject9F59E8AA
-            - '",{"yAxis":"left","period":300,"stat":"Average"}]],"annotations":{"horizontal":[]},"yAxis":{"left":{"min":0},"right":{"min":0}}}},{"type":"metric","width":6,"height":6,"x":0,"y":8,"properties":{"view":"timeSeries","title":"Test
-              HelloLinux Duration","region":"'
-            - Ref: AWS::Region
-            - '","metrics":[["AWS/CodeBuild","Duration","ProjectName","'
-            - Ref: CodeCommitPipelineHelloLinux82ECC4D2
-            - '",{"yAxis":"left","period":300,"stat":"Average"}]],"annotations":{"horizontal":[]},"yAxis":{"left":{"min":0},"right":{"min":0}}}},{"type":"metric","width":6,"height":6,"x":0,"y":14,"properties":{"view":"timeSeries","title":"Test
-              HelloWindows Duration","region":"'
-            - Ref: AWS::Region
-            - '","metrics":[["AWS/CodeBuild","Duration","ProjectName","'
-            - Ref: CodeCommitPipelineHelloWindows397414E5
-            - '",{"yAxis":"left","period":300,"stat":"Average"}]],"annotations":{"horizontal":[]},"yAxis":{"left":{"min":0},"right":{"min":0}}}}]}'
-      DashboardName: delivlib-test-CodeCommitPipelineDashboard6FF06F29
-    Metadata:
-      aws:cdk:path: delivlib-test/CodeCommitPipeline/Dashboard/Resource
   CodeCommitPipelineHelloLinuxRoleFA5AA729:
     Type: AWS::IAM::Role
     Properties:
@@ -818,6 +834,28 @@ Resources:
         Type: CODEPIPELINE
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/HelloLinux/Resource/Resource/Resource
+  CodeCommitPipelineHelloLinuxOnBuildFailedD1EEA29A:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+          - aws.codebuild
+        detail-type:
+          - CodeBuild Build State Change
+        detail:
+          project-name:
+            - Ref: CodeCommitPipelineHelloLinux82ECC4D2
+          build-status:
+            - FAILED
+      State: ENABLED
+      Targets:
+        - Arn:
+            Ref: CodeCommitPipelineNotificationsTopic36C2D667
+          Id: NotificationsTopic
+          InputTransformer:
+            InputTemplate: '"Test HelloLinux failed"'
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/HelloLinux/Resource/Resource/OnBuildFailed/Resource
   CodeCommitPipelineHelloWindowsRole1F446E70:
     Type: AWS::IAM::Role
     Properties:
@@ -968,6 +1006,28 @@ Resources:
         Type: CODEPIPELINE
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/HelloWindows/Resource/Resource/Resource
+  CodeCommitPipelineHelloWindowsOnBuildFailed0BED9349:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+          - aws.codebuild
+        detail-type:
+          - CodeBuild Build State Change
+        detail:
+          project-name:
+            - Ref: CodeCommitPipelineHelloWindows397414E5
+          build-status:
+            - FAILED
+      State: ENABLED
+      Targets:
+        - Arn:
+            Ref: CodeCommitPipelineNotificationsTopic36C2D667
+          Id: NotificationsTopic
+          InputTransformer:
+            InputTemplate: '"Test HelloWindows failed"'
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/HelloWindows/Resource/Resource/OnBuildFailed/Resource
   CodeCommitPipelineNpmRole219D5F49:
     Type: AWS::IAM::Role
     Properties:
@@ -1833,6 +1893,9 @@ Resources:
           - Name: GITHUB_REPO
             Type: PLAINTEXT
             Value: git@github.com:awslabs/aws-delivlib-sample
+          - Name: GITHUB_PAGES_BRANCH
+            Type: PLAINTEXT
+            Value: gh-pages
           - Name: SSH_KEY_SECRET
             Type: PLAINTEXT
             Value: arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/github-ssh-lwzfjW

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -1,17 +1,60 @@
-import { expect, haveResource } from '@aws-cdk/assert';
+import { expect as cdk_expect, haveResource } from '@aws-cdk/assert';
+import codebuild = require('@aws-cdk/aws-codebuild');
 import codecommit = require('@aws-cdk/aws-codecommit');
 import cdk = require('@aws-cdk/cdk');
+import path = require('path');
 import delivlib = require('../lib');
 
 test('pipelineName can be used to set a physical name for the pipeline', async () => {
   const stack = new cdk.Stack();
 
   new delivlib.Pipeline(stack, 'Pipeline', {
-    repo: new delivlib.CodeCommitRepo(new codecommit.Repository(stack, 'Repo', { repositoryName: 'test' })),
+    repo: createTestRepo(stack),
     pipelineName: 'HelloPipeline'
   });
 
-  expect(stack).to(haveResource('AWS::CodePipeline::Pipeline', {
+  cdk_expect(stack).to(haveResource('AWS::CodePipeline::Pipeline', {
     Name: 'HelloPipeline'
   }));
 });
+
+test('concurrency: enabled by default', async () => {
+  const stack = new cdk.Stack();
+
+  createTestPipeline(stack);
+
+  const template = stack.toCloudFormation();
+
+  expect(template.Resources.PipelineBuildPipeline04C6628A.Properties.Stages.length).toBe(4);
+});
+
+test('concurrency: when disabled, we get a stage for each action', async () => {
+  const stack = new cdk.Stack();
+  createTestPipeline(stack, { concurrency: false } as any);
+  const template = stack.toCloudFormation();
+  expect(template.Resources.PipelineBuildPipeline04C6628A.Properties.Stages.length).toBe(7);
+});
+
+function createTestPipeline(stack: cdk.Stack, props?: delivlib.PipelineProps) {
+  const pipeline = new delivlib.Pipeline(stack, 'Pipeline', {
+    repo: createTestRepo(stack),
+    ...props
+  });
+
+  const project = new codebuild.Project(stack, 'publish', {
+    buildSpec: { version: '0.2' }
+  });
+
+  const testDirectory = path.join(__dirname, 'delivlib-tests', 'linux');
+  pipeline.addTest('test1', { testDirectory, platform: delivlib.ShellPlatform.LinuxUbuntu });
+  pipeline.addTest('test2', { testDirectory, platform: delivlib.ShellPlatform.LinuxUbuntu });
+  pipeline.addPublish({ id: 'pub1', project });
+  pipeline.addPublish({ id: 'pub2', project });
+  pipeline.addPublish({ id: 'pub3', project });
+
+  return pipeline;
+}
+
+function createTestRepo(stack: cdk.Stack) {
+  return new delivlib.CodeCommitRepo(new codecommit.Repository(stack, 'Repo', { repositoryName: 'test' }));
+}

--- a/test/test-stack.ts
+++ b/test/test-stack.ts
@@ -24,6 +24,7 @@ export class TestStack extends cdk.Stack {
     const pipeline = new delivlib.Pipeline(this, 'CodeCommitPipeline', {
       title: 'aws-delivlib test pipeline',
       repo,
+      concurrency: false, // temporary until we increase the account limits
       env: {
         DELIVLIB_ENV_TEST: 'MAGIC_1924'
       }

--- a/test/test-stack.ts
+++ b/test/test-stack.ts
@@ -24,7 +24,7 @@ export class TestStack extends cdk.Stack {
     const pipeline = new delivlib.Pipeline(this, 'CodeCommitPipeline', {
       title: 'aws-delivlib test pipeline',
       repo,
-      concurrency: false, // temporary until we increase the account limits
+      concurrency: 1, // temporary until we increase the account limits
       notificationEmail: 'aws-cdk-dev+delivlib-test@amazon.com',
       env: {
         DELIVLIB_ENV_TEST: 'MAGIC_1924'


### PR DESCRIPTION
If `concurrency` is set to a number, no more than N actions will be run concurrently in the TEST and PUBLISH stages.

This allows overcoming the default account limitation of a 1 concurrency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
