### PR TITLE
feat(pipeline): send email notifications on any action failure

### DIFF
--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -35,7 +35,7 @@ export interface PipelineProps {
   branch?: string;
 
   /**
-   * Email to send notifications.
+   * Email to send failure notifications.
    * @default No email notifications
    */
   notificationEmail?: string;
@@ -92,10 +92,8 @@ export class Pipeline extends cdk.Construct {
 
   private readonly pipeline: cpipeline.Pipeline;
   private readonly buildOutput: cpipelineapi.Artifact;
-  private readonly repo: string;
   private readonly branch: string;
   private readonly notify?: sns.Topic;
-  private readonly title: string;
   private testStage?: cpipeline.Stage;
   private publishStage?: cpipeline.Stage;
 
@@ -107,7 +105,6 @@ export class Pipeline extends cdk.Construct {
       restartExecutionOnUpdate: props.restartExecutionOnUpdate === undefined ? true : props.restartExecutionOnUpdate
     });
 
-    this.repo = props.repo.describe();
     this.branch = props.branch || 'master';
     const source = props.repo.createSourceStage(this.pipeline, this.branch);
 
@@ -137,34 +134,11 @@ export class Pipeline extends cdk.Construct {
       this.notify.subscribeEmail('NotifyEmail', props.notificationEmail);
     }
 
-    if (this.notify) {
-      buildProject.onBuildStarted('OnBuildStarted').addTarget(this.notify, {
-        textTemplate: new cdk.FnConcat('[in-progress] ', this.repo, ` branch ${this.branch} - build started`)
-      });
-
-      buildProject.onBuildSucceeded('OnBuildSuccessful').addTarget(this.notify, {
-        textTemplate: new cdk.FnConcat('[success] ', this.repo, ` branch ${this.branch} - build succeeded.`)
-      });
-
-      buildProject.onBuildFailed('OnBuildFailed').addTarget(this.notify, {
-        textTemplate: new cdk.FnConcat('[failure] ', this.repo, ` branch ${this.branch} - build failed`)
-      });
-    }
-
-    // trigger an SNS topic every time the pipeline fails
+    // add a failure alarm for the entire pipeline.
     this.addFailureAlarm(props.title);
 
-    this.title = props.title || 'Pipeline';
-
-    // define an alarm triggered when the build fails.
-    if (this.notify) {
-      const alarm = buildProject.metricFailedBuilds().newAlarm(this, 'FailedBuildsAlarm', {
-        threshold: 1,
-        evaluationPeriods: 1,
-      });
-
-      alarm.onAlarm(this.notify);
-    }
+    // emit an SNS notification every time build fails.
+    this.addBuildFailureNotification(buildProject, `${props.title} build failed`);
   }
 
   public addTest(id: string, props: TestableProps) {
@@ -175,15 +149,7 @@ export class Pipeline extends cdk.Construct {
     const test = new Testable(this, id, props);
     test.addToPipeline(this.testStage, this.buildOutput);
 
-    if (this.notify) {
-      const alarm = test.project.metricFailedBuilds().newAlarm(test /* add as child of test */, 'FailedTests', {
-        alarmDescription: `Test ${id} in pipeline ${this.title} has failed`,
-        threshold: 1,
-        evaluationPeriods: 1
-      });
-
-      alarm.onAlarm(this.notify);
-    }
+    this.addBuildFailureNotification(test.project, `Test ${id} failed`);
   }
 
   public addPublish(publisher: IPublisher) {
@@ -233,6 +199,15 @@ export class Pipeline extends cdk.Construct {
       pipeline: this.pipeline,
       title
     }).alarm;
+  }
+  private addBuildFailureNotification(buildProject: cbuild.Project, message: string) {
+    if (!this.notify) {
+      return;
+    }
+
+    buildProject.onBuildFailed('OnBuildFailed').addTarget(this.notify, {
+      textTemplate: message
+    });
   }
 }
 

--- a/pipeline/delivlib.ts
+++ b/pipeline/delivlib.ts
@@ -21,6 +21,7 @@ export class DelivLibPipelineStack extends cdk.Stack {
     const pipeline = new delivlib.Pipeline(this, 'GitHubPipeline', {
       title: 'aws-delivlib production pipeline',
       repo: github,
+      notificationEmail: 'aws-cdk-dev+delivlib-notify@amazon.com',
       buildSpec: {
         version: '0.2',
         phases: {

--- a/test/test-stack.ts
+++ b/test/test-stack.ts
@@ -24,6 +24,7 @@ export class TestStack extends cdk.Stack {
     const pipeline = new delivlib.Pipeline(this, 'CodeCommitPipeline', {
       title: 'aws-delivlib test pipeline',
       repo,
+      notificationEmail: 'aws-cdk-dev+delivlib-test@amazon.com',
       env: {
         DELIVLIB_ENV_TEST: 'MAGIC_1924'
       }


### PR DESCRIPTION
If `notificationEmail` is set, send an SNS notification to the
specified email when any of the build/test/publish actions are failing.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
