### PR TITLE
fix: Logger reference in CSC custom resources

### DIFF
--- a/lib/code-signing/certificate-signing-request.ts
+++ b/lib/code-signing/certificate-signing-request.ts
@@ -48,6 +48,8 @@ export class CertificateSigningRequest extends cdk.Construct {
 
     const customResource = new lambda.SingletonFunction(this, 'ResourceHandler', {
       uuid: '541F6782-6DCF-49A7-8C5A-67715ADD9E4C',
+      lambdaPurpose: 'CreateCSR',
+      description: 'Creates a Certificate Signing Request document for an x509 certificate',
       runtime: lambda.Runtime.Python36,
       handler: 'index.main',
       code: new lambda.AssetCode(path.join(__dirname, 'certificate-signing-request')),

--- a/lib/code-signing/certificate-signing-request/index.py
+++ b/lib/code-signing/certificate-signing-request/index.py
@@ -23,116 +23,116 @@ CFN_SUCCESS = "SUCCESS"
 CFN_FAILED = "FAILED"
 
 def handle_event(event, aws_request_id):
-  import boto3, subprocess, tempfile
+   import boto3, subprocess, tempfile
 
-  props = event['ResourceProperties']
+   props = event['ResourceProperties']
 
-  if event['RequestType'] in ['Create', 'Update']:
-    with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as config:
-      # Creating a CSR Config file
-      config.write('[ req ]\n')
-      config.write('default_md           = sha256\n')
-      config.write('distinguished_name   = dn\n')
-      config.write('prompt               = no\n')
-      config.write('req_extensions       = extensions\n')
-      config.write('string_mask          = utf8only\n')
-      config.write('utf8                 = yes\n')
-      config.write('\n')
-      config.write('[ dn ]\n')
-      config.write('CN                   = %s\n' % props['DnCommonName'])
-      config.write('C                    = %s\n' % props['DnCountry'])
-      config.write('ST                   = %s\n' % props['DnStateOrProvince'])
-      config.write('L                    = %s\n' % props['DnLocality'])
-      config.write('O                    = %s\n' % props['DnOrganizationName'])
-      config.write('OU                   = %s\n' % props['DnOrganizationalUnitName'])
-      config.write('emailAddress         = %s\n' % props['DnEmailAddress'])
-      config.write('\n')
-      config.write('[ extensions ]\n')
-      config.write('extendedKeyUsage     = %s\n' % props['ExtendedKeyUsage'])
-      config.write('keyUsage             = %s\n' % props['KeyUsage'])
-      config.write('subjectKeyIdentifier = hash\n')
-      config.flush()
+   if event['RequestType'] in ['Create', 'Update']:
+      with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as config:
+         # Creating a CSR Config file
+         config.write('[ req ]\n')
+         config.write('default_md           = sha256\n')
+         config.write('distinguished_name   = dn\n')
+         config.write('prompt               = no\n')
+         config.write('req_extensions       = extensions\n')
+         config.write('string_mask          = utf8only\n')
+         config.write('utf8                 = yes\n')
+         config.write('\n')
+         config.write('[ dn ]\n')
+         config.write('CN                   = %s\n' % props['DnCommonName'])
+         config.write('C                    = %s\n' % props['DnCountry'])
+         config.write('ST                   = %s\n' % props['DnStateOrProvince'])
+         config.write('L                    = %s\n' % props['DnLocality'])
+         config.write('O                    = %s\n' % props['DnOrganizationName'])
+         config.write('OU                   = %s\n' % props['DnOrganizationalUnitName'])
+         config.write('emailAddress         = %s\n' % props['DnEmailAddress'])
+         config.write('\n')
+         config.write('[ extensions ]\n')
+         config.write('extendedKeyUsage     = %s\n' % props['ExtendedKeyUsage'])
+         config.write('keyUsage             = %s\n' % props['KeyUsage'])
+         config.write('subjectKeyIdentifier = hash\n')
+         config.flush()
 
-      with tempfile.TemporaryDirectory() as tmpdir:
-        with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as pkey:
-          secret = boto3.client('secretsmanager').get_secret_value(SecretId=props['PrivateKeySecretId'])
-          pkey.write(secret['SecretString'])
-          pkey.flush()
+         with tempfile.TemporaryDirectory() as tmpdir:
+            with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as pkey:
+               secret = boto3.client('secretsmanager').get_secret_value(SecretId=props['PrivateKeySecretId'])
+               pkey.write(secret['SecretString'])
+               pkey.flush()
 
-          csr_file = os.path.join(tmpdir, 'csr.pem')
-          self_signed_cert = os.path.join(tmpdir, 'self-signed-cert.pem')
+               csr_file = os.path.join(tmpdir, 'csr.pem')
+               self_signed_cert = os.path.join(tmpdir, 'self-signed-cert.pem')
 
-          subprocess.check_call([
-            'openssl', 'req', '-config', config.name,
-                              '-key', pkey.name,
-                              '-out', csr_file,
-                              '-new'
-          ])
+               subprocess.check_call([
+                  'openssl', 'req', '-config', config.name,
+                                    '-key', pkey.name,
+                                    '-out', csr_file,
+                                    '-new'
+               ])
 
-          subprocess.check_call([
-            'openssl', 'x509', '-in', csr_file,
-                               '-out', self_signed_cert,
-                               '-req',
-                               '-signkey', pkey.name,
-                               '-days', '365'
-          ])
+               subprocess.check_call([
+                  'openssl', 'x509', '-in', csr_file,
+                                    '-out', self_signed_cert,
+                                    '-req',
+                                    '-signkey', pkey.name,
+                                    '-days', '365'
+               ])
 
-        with open(csr_file) as csr:
-          with open(self_signed_cert) as cert:
-            return {
-              'CSR': csr.read(),
-              'SelfSignedCertificate': cert.read()
-            }
+            with open(csr_file) as csr:
+               with open(self_signed_cert) as cert:
+                  return {
+                     'CSR': csr.read(),
+                     'SelfSignedCertificate': cert.read()
+                  }
 
-  elif event['RequestType'] == 'Delete':
-    # Nothing to do - the CSR isn't quite a "material" resource
-    return {}
+   elif event['RequestType'] == 'Delete':
+      # Nothing to do - the CSR isn't quite a "material" resource
+      return {}
 
-  else:
+   else:
       raise Exception('Unsupported RequestType: %s' % event['RequestType'])
 
 def main(event, context):
-  log.getLogger().setLevel(log.INFO)
+   log.getLogger().setLevel(log.INFO)
 
-  try:
-    log.info('Input event: %s', event)
-    attributes = handle_event(event, context.aws_request_id)
-    cfn_send(event, context, CFN_SUCCESS, attributes, event['LogicalResourceId'])
-  except KeyError as e:
-    cfn_send(event, context, CFN_FAILED, {}, reason="Invalid request: missing key %s" % str(e))
-  except Exception as e:
-    log.exception(e)
-    cfn_send(event, context, CFN_FAILED, {}, reason=str(e))
+   try:
+      log.info('Input event: %s', event)
+      attributes = handle_event(event, context.aws_request_id)
+      cfn_send(event, context, CFN_SUCCESS, attributes, event['LogicalResourceId'])
+   except KeyError as e:
+      cfn_send(event, context, CFN_FAILED, {}, reason="Invalid request: missing key %s" % str(e))
+   except Exception as e:
+      log.exception(e)
+      cfn_send(event, context, CFN_FAILED, {}, reason=str(e))
 
 #---------------------------------------------------------------------------------------------------
 # sends a response to cloudformation
 def cfn_send(event, context, responseStatus, responseData={}, physicalResourceId=None, noEcho=False, reason=None):
-  responseUrl = event['ResponseURL']
-  log.info(responseUrl)
+   responseUrl = event['ResponseURL']
+   log.info(responseUrl)
 
-  body = json.dumps({
-    'Status': responseStatus,
-    'Reason': reason or ('See the details in CloudWatch Log Stream: ' + context.log_stream_name),
-    'PhysicalResourceId': physicalResourceId or context.log_stream_name,
-    'StackId': event['StackId'],
-    'RequestId': event['RequestId'],
-    'LogicalResourceId': event['LogicalResourceId'],
-    'NoEcho': noEcho,
-    'Data': responseData,
-  })
-  log.info("| response body:\n" + body)
+   body = json.dumps({
+      'Status': responseStatus,
+      'Reason': reason or ('See the details in CloudWatch Log Stream: ' + context.log_stream_name),
+      'PhysicalResourceId': physicalResourceId or context.log_stream_name,
+      'StackId': event['StackId'],
+      'RequestId': event['RequestId'],
+      'LogicalResourceId': event['LogicalResourceId'],
+      'NoEcho': noEcho,
+      'Data': responseData,
+   })
+   log.info("| response body:\n" + body)
 
-  headers = {
-    'content-type' : 'application/json',
-    'content-length' : str(len(body))
-  }
+   headers = {
+      'content-type' : 'application/json',
+      'content-length' : str(len(body))
+   }
 
-  try:
-    response = requests.put(responseUrl, data=body, headers=headers)
-    log.info("| status code: " + response.reason)
-  except Exception as e:
-    log.error("| unable to send response to CloudFormation")
-    log.exception(e)
+   try:
+      response = requests.put(responseUrl, data=body, headers=headers)
+      log.info("| status code: " + response.reason)
+   except Exception as e:
+      log.error("| unable to send response to CloudFormation")
+      log.exception(e)
 
 if __name__ == '__main__':
-  handle_event(json.load(sys.stdin), '61120008-4da7-40e1-b180-5ce50a6b90ad')
+   handle_event(json.load(sys.stdin), '61120008-4da7-40e1-b180-5ce50a6b90ad')

--- a/lib/code-signing/private-key.py
+++ b/lib/code-signing/private-key.py
@@ -19,84 +19,84 @@ CFN_SUCCESS = "SUCCESS"
 CFN_FAILED = "FAILED"
 
 def handle_event(event, aws_request_id):
-  import boto3, shutil, subprocess, tempfile
+   import boto3, shutil, subprocess, tempfile
 
-  props = event['ResourceProperties']
+   props = event['ResourceProperties']
 
-  if event['RequestType'] == 'Update':
-    # Prohibit updates - you don't want to inadertently cause your private key to change...
-    raise Exception('X509 Private Key update requires replacement, a new resource must be created!')
+   if event['RequestType'] == 'Update':
+      # Prohibit updates - you don't want to inadertently cause your private key to change...
+      raise Exception('X509 Private Key update requires replacement, a new resource must be created!')
 
-  elif event['RequestType'] == 'Create':
-    tmpdir = tempfile.mkdtemp()
-    with tempfile.TemporaryDirectory() as tmpdir:
-      pkey_file = os.path.join(tmpdir, 'private_key.pem')
-      subprocess.check_call(['openssl', 'genrsa', '-out', pkey_file, props['KeySize']], shell=False)
-      with open(pkey_file) as pkey:
-        opts = {
-          'ClientRequestToken': aws_request_id,
-          'Description': props.get('Description'),
-          'Name': props['SecretName'],
-          'SecretString': pkey.read()
-        }
+   elif event['RequestType'] == 'Create':
+      tmpdir = tempfile.mkdtemp()
+      with tempfile.TemporaryDirectory() as tmpdir:
+         pkey_file = os.path.join(tmpdir, 'private_key.pem')
+         subprocess.check_call(['openssl', 'genrsa', '-out', pkey_file, props['KeySize']], shell=False)
+         with open(pkey_file) as pkey:
+            opts = {
+               'ClientRequestToken': aws_request_id,
+               'Description': props.get('Description'),
+               'Name': props['SecretName'],
+               'SecretString': pkey.read()
+            }
 
-        kmsKeyId = props.get('KmsKeyId')
-        if kmsKeyId: opts['KmsKeyId'] = kmsKeyId
+            kmsKeyId = props.get('KmsKeyId')
+            if kmsKeyId: opts['KmsKeyId'] = kmsKeyId
 
-        ret = boto3.client('secretsmanager').create_secret(**opts)
-        return {'ARN': ret['ARN'], 'VersionId': ret['VersionId']}
+            ret = boto3.client('secretsmanager').create_secret(**opts)
+            return {'ARN': ret['ARN'], 'VersionId': ret['VersionId']}
 
-  elif event['RequestType'] == 'Delete':
-    if event['PhysicalResourceId'].startswith('arn:'): # Only if the resource had been successfully created before
-      boto3.client('secretsmanager').delete_secret(SecretId=event['PhysicalResourceId'])
-    return {'ARN': ''}
+   elif event['RequestType'] == 'Delete':
+      if event['PhysicalResourceId'].startswith('arn:'): # Only if the resource had been successfully created before
+         boto3.client('secretsmanager').delete_secret(SecretId=event['PhysicalResourceId'])
+      return {'ARN': ''}
 
-  else:
+   else:
       raise Exception('Unsupported RequestType: %s' % event['RequestType'])
 
 def main(event, context):
-  log.getLogger().setLevel(log.INFO)
+   log.getLogger().setLevel(log.INFO)
 
-  try:
-    log.info('Input event: %s', event)
-    attributes = handle_event(event, context.aws_request_id)
-    cfn_send(event, context, CFN_SUCCESS, attributes, attributes['ARN'])
-  except KeyError as e:
-    cfn_send(event, context, CFN_FAILED, {}, reason="Invalid request: missing key %s" % str(e))
-  except Exception as e:
-    log.exception(e)
-    cfn_send(event, context, CFN_FAILED, {}, reason=str(e))
+   try:
+      log.info('Input event: %s', event)
+      attributes = handle_event(event, context.aws_request_id)
+      cfn_send(event, context, CFN_SUCCESS, attributes, attributes['ARN'])
+   except KeyError as e:
+      cfn_send(event, context, CFN_FAILED, {}, reason="Invalid request: missing key %s" % str(e))
+   except Exception as e:
+      log.exception(e)
+      cfn_send(event, context, CFN_FAILED, {}, reason=str(e))
 
 #---------------------------------------------------------------------------------------------------
 # sends a response to cloudformation
 def cfn_send(event, context, responseStatus, responseData={}, physicalResourceId=None, noEcho=False, reason=None):
-  responseUrl = event['ResponseURL']
-  log.info(responseUrl)
+   responseUrl = event['ResponseURL']
+   log.info(responseUrl)
 
-  responseBody = {}
-  responseBody['Status'] = responseStatus
-  responseBody['Reason'] = reason or ('See the details in CloudWatch Log Stream: ' + context.log_stream_name)
-  responseBody['PhysicalResourceId'] = physicalResourceId or context.log_stream_name
-  responseBody['StackId'] = event['StackId']
-  responseBody['RequestId'] = event['RequestId']
-  responseBody['LogicalResourceId'] = event['LogicalResourceId']
-  responseBody['NoEcho'] = noEcho
-  responseBody['Data'] = responseData
+   responseBody = {}
+   responseBody['Status'] = responseStatus
+   responseBody['Reason'] = reason or ('See the details in CloudWatch Log Stream: ' + context.log_stream_name)
+   responseBody['PhysicalResourceId'] = physicalResourceId or context.log_stream_name
+   responseBody['StackId'] = event['StackId']
+   responseBody['RequestId'] = event['RequestId']
+   responseBody['LogicalResourceId'] = event['LogicalResourceId']
+   responseBody['NoEcho'] = noEcho
+   responseBody['Data'] = responseData
 
-  body = json.dumps(responseBody)
-  log.info("| response body:\n" + body)
+   body = json.dumps(responseBody)
+   log.info("| response body:\n" + body)
 
-  headers = {
-    'content-type' : 'application/json',
-    'content-length' : str(len(body))
-  }
+   headers = {
+      'content-type' : 'application/json',
+      'content-length' : str(len(body))
+   }
 
-  try:
-    response = requests.put(responseUrl, data=body, headers=headers)
-    log.info("| status code: " + response.reason)
-  except Exception as e:
-    log.error("| unable to send response to CloudFormation")
-    log.exception(e)
+   try:
+      response = requests.put(responseUrl, data=body, headers=headers)
+      log.info("| status code: " + response.reason)
+   except Exception as e:
+      log.error("| unable to send response to CloudFormation")
+      log.exception(e)
 
 if __name__ == '__main__':
-  handle_event(json.load(sys.stdin), 'ec92d8a9-672c-4647-9d34-0d3159a2c692')
+   handle_event(json.load(sys.stdin), 'ec92d8a9-672c-4647-9d34-0d3159a2c692')

--- a/lib/code-signing/private-key.ts
+++ b/lib/code-signing/private-key.ts
@@ -65,6 +65,7 @@ export class RsaPrivateKeySecret extends cdk.Construct {
 
     const customResource = new lambda.SingletonFunction(this, 'ResourceHandler', {
       uuid: '72FD327D-3813-4632-9340-28EC437AA486',
+      description: 'Generates an RSA Private Key and stores it in AWS Secrets Manager',
       runtime: lambda.Runtime.Python36,
       handler: 'index.main',
       code: new lambda.InlineCode(

--- a/lib/pgp-secret.ts
+++ b/lib/pgp-secret.ts
@@ -69,6 +69,7 @@ export class PGPSecret extends cdk.Construct {
 
     const fn = new lambda.SingletonFunction(this, 'Lambda', {
       uuid: 'f25803d3-054b-44fc-985f-4860d7d6ee74',
+      description: 'Generates an OpenPGP Key and stores the private key in Secrets Manager and the public key in an SSM Parameter',
       code: new lambda.InlineCode(fs.readFileSync(path.join(__dirname, 'pgpresource.py'), { encoding: 'utf-8' })),
       handler: 'index.main',
       timeout: 300,

--- a/test/expected.json
+++ b/test/expected.json
@@ -2150,69 +2150,69 @@ Resources:
           CFN_FAILED = "FAILED"
 
           def handle_event(event, aws_request_id):
-            import boto3, shutil, subprocess, tempfile
-            props = event['ResourceProperties']
-            if event['RequestType'] == 'Update':
-              raise Exception('X509 Private Key update requires replacement, a new resource must be created!')
-            elif event['RequestType'] == 'Create':
-              tmpdir = tempfile.mkdtemp()
-              with tempfile.TemporaryDirectory() as tmpdir:
-                pkey_file = os.path.join(tmpdir, 'private_key.pem')
-                subprocess.check_call(['openssl', 'genrsa', '-out', pkey_file, props['KeySize']], shell=False)
-                with open(pkey_file) as pkey:
-                  opts = {
-                    'ClientRequestToken': aws_request_id,
-                    'Description': props.get('Description'),
-                    'Name': props['SecretName'],
-                    'SecretString': pkey.read()
-                  }
-                  kmsKeyId = props.get('KmsKeyId')
-                  if kmsKeyId: opts['KmsKeyId'] = kmsKeyId
-                  ret = boto3.client('secretsmanager').create_secret(**opts)
-                  return {'ARN': ret['ARN'], 'VersionId': ret['VersionId']}
-            elif event['RequestType'] == 'Delete':
-              if event['PhysicalResourceId'].startswith('arn:'): # Only if the resource had been successfully created before
-                boto3.client('secretsmanager').delete_secret(SecretId=event['PhysicalResourceId'])
-              return {'ARN': ''}
-            else:
+             import boto3, shutil, subprocess, tempfile
+             props = event['ResourceProperties']
+             if event['RequestType'] == 'Update':
+                raise Exception('X509 Private Key update requires replacement, a new resource must be created!')
+             elif event['RequestType'] == 'Create':
+                tmpdir = tempfile.mkdtemp()
+                with tempfile.TemporaryDirectory() as tmpdir:
+                   pkey_file = os.path.join(tmpdir, 'private_key.pem')
+                   subprocess.check_call(['openssl', 'genrsa', '-out', pkey_file, props['KeySize']], shell=False)
+                   with open(pkey_file) as pkey:
+                      opts = {
+                         'ClientRequestToken': aws_request_id,
+                         'Description': props.get('Description'),
+                         'Name': props['SecretName'],
+                         'SecretString': pkey.read()
+                      }
+                      kmsKeyId = props.get('KmsKeyId')
+                      if kmsKeyId: opts['KmsKeyId'] = kmsKeyId
+                      ret = boto3.client('secretsmanager').create_secret(**opts)
+                      return {'ARN': ret['ARN'], 'VersionId': ret['VersionId']}
+             elif event['RequestType'] == 'Delete':
+                if event['PhysicalResourceId'].startswith('arn:'): # Only if the resource had been successfully created before
+                   boto3.client('secretsmanager').delete_secret(SecretId=event['PhysicalResourceId'])
+                return {'ARN': ''}
+             else:
                 raise Exception('Unsupported RequestType: %s' % event['RequestType'])
           def main(event, context):
-            log.getLogger().setLevel(log.INFO)
-            try:
-              log.info('Input event: %s', event)
-              attributes = handle_event(event, context.aws_request_id)
-              cfn_send(event, context, CFN_SUCCESS, attributes, attributes['ARN'])
-            except KeyError as e:
-              cfn_send(event, context, CFN_FAILED, {}, reason="Invalid request: missing key %s" % str(e))
-            except Exception as e:
-              log.exception(e)
-              cfn_send(event, context, CFN_FAILED, {}, reason=str(e))
+             log.getLogger().setLevel(log.INFO)
+             try:
+                log.info('Input event: %s', event)
+                attributes = handle_event(event, context.aws_request_id)
+                cfn_send(event, context, CFN_SUCCESS, attributes, attributes['ARN'])
+             except KeyError as e:
+                cfn_send(event, context, CFN_FAILED, {}, reason="Invalid request: missing key %s" % str(e))
+             except Exception as e:
+                log.exception(e)
+                cfn_send(event, context, CFN_FAILED, {}, reason=str(e))
           def cfn_send(event, context, responseStatus, responseData={}, physicalResourceId=None, noEcho=False, reason=None):
-              responseUrl = event['ResponseURL']
-              logger.info(responseUrl)
-              responseBody = {}
-              responseBody['Status'] = responseStatus
-              responseBody['Reason'] = reason or ('See the details in CloudWatch Log Stream: ' + context.log_stream_name)
-              responseBody['PhysicalResourceId'] = physicalResourceId or context.log_stream_name
-              responseBody['StackId'] = event['StackId']
-              responseBody['RequestId'] = event['RequestId']
-              responseBody['LogicalResourceId'] = event['LogicalResourceId']
-              responseBody['NoEcho'] = noEcho
-              responseBody['Data'] = responseData
-              body = json.dumps(responseBody)
-              logger.info("| response body:\n" + body)
-              headers = {
-                  'content-type' : '',
-                  'content-length' : str(len(body))
-              }
-              try:
-                  response = requests.put(responseUrl, data=body, headers=headers)
-                  logger.info("| status code: " + response.reason)
-              except Exception as e:
-                  logger.error("| unable to send response to CloudFormation")
-                  logger.exception(e)
+             responseUrl = event['ResponseURL']
+             log.info(responseUrl)
+             responseBody = {}
+             responseBody['Status'] = responseStatus
+             responseBody['Reason'] = reason or ('See the details in CloudWatch Log Stream: ' + context.log_stream_name)
+             responseBody['PhysicalResourceId'] = physicalResourceId or context.log_stream_name
+             responseBody['StackId'] = event['StackId']
+             responseBody['RequestId'] = event['RequestId']
+             responseBody['LogicalResourceId'] = event['LogicalResourceId']
+             responseBody['NoEcho'] = noEcho
+             responseBody['Data'] = responseData
+             body = json.dumps(responseBody)
+             log.info("| response body:\n" + body)
+             headers = {
+                'content-type' : 'application/json',
+                'content-length' : str(len(body))
+             }
+             try:
+                response = requests.put(responseUrl, data=body, headers=headers)
+                log.info("| status code: " + response.reason)
+             except Exception as e:
+                log.error("| unable to send response to CloudFormation")
+                log.exception(e)
           if __name__ == '__main__':
-            handle_event(json.load(sys.stdin), 'ec92d8a9-672c-4647-9d34-0d3159a2c692')
+             handle_event(json.load(sys.stdin), 'ec92d8a9-672c-4647-9d34-0d3159a2c692')
       Handler: index.main
       Role:
         Fn::GetAtt:


### PR DESCRIPTION
The lambda code that back the Code Signing Certificate resources were
referencing the `logging` module using an incorrect name. This fixes the
incorrect naming, and adds descriptions to the Lambda functions (as well
as tagging a `purpose` on the entities that can be safely replaced).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
