### PR TITLE
Expose the failure alarm as a public property

### DIFF
--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -100,6 +100,7 @@ export interface PipelineProps {
  */
 export class Pipeline extends cdk.Construct {
   public buildRole?: iam.Role;
+  public readonly failureAlarm: cloudwatch.Alarm;
 
   private readonly pipeline: cpipeline.Pipeline;
   private readonly buildOutput: cpipelineapi.Artifact;
@@ -149,7 +150,7 @@ export class Pipeline extends cdk.Construct {
     }
 
     // add a failure alarm for the entire pipeline.
-    this.addFailureAlarm(props.title);
+    this.failureAlarm = this.addFailureAlarm(props.title);
 
     // emit an SNS notification every time build fails.
     this.addBuildFailureNotification(buildProject, `${props.title} build failed`);


### PR DESCRIPTION
*Issue #, if available:*
(internal)
*Description of changes:*
Exposes the failure alarm as a public property - we need this to configure our alarming actions internally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
