### PR TITLE
fix: Stop surfacing and using secret VersionIds

### DIFF
--- a/lib/code-signing/certificate-signing-request.ts
+++ b/lib/code-signing/certificate-signing-request.ts
@@ -65,7 +65,6 @@ export class CertificateSigningRequest extends cdk.Construct {
         resourceVersion: hashFileOrDirectory(codeLocation),
         // Private key
         privateKeySecretId: props.privateKey.secretArn,
-        privateKeySecretVersion: props.privateKey.secretVersion,
         // Distinguished name
         dnCommonName: props.dn.commonName,
         dnCountry: props.dn.country,

--- a/lib/code-signing/code-signing-certificate.ts
+++ b/lib/code-signing/code-signing-certificate.ts
@@ -84,11 +84,6 @@ export class CodeSigningCertificate extends cdk.Construct implements ICodeSignin
   public readonly privatePartSecretArn: string;
 
   /**
-   * The ID of the version of the AWS Secrets Manager secret that holds the private key for this CSC
-   */
-  public readonly privatePartSecretVersionId: string;
-
-  /**
    * The ARN of the AWS SSM Parameter that holds the certificate for this CSC.
    */
   public readonly publicPartParameterArn: string;
@@ -124,7 +119,6 @@ export class CodeSigningCertificate extends cdk.Construct implements ICodeSignin
     this.secretEncryptionKey = props.secretEncryptionKey;
 
     this.privatePartSecretArn = privateKey.secretArn;
-    this.privatePartSecretVersionId = privateKey.secretVersion;
 
     let certificate = props.pemCertificate;
 
@@ -149,7 +143,7 @@ export class CodeSigningCertificate extends cdk.Construct implements ICodeSignin
     this.publicPartParameterName = `/${paramName}`;
 
     new ssm.CfnParameter(this, 'Resource', {
-      description: `A PEM-encoded Code-Signing Certificate (private key in ${privateKey.secretArn} version ${privateKey.secretVersion})`,
+      description: `A PEM-encoded Code-Signing Certificate (private key in ${privateKey.secretArn})`,
       name: this.publicPartParameterName,
       type: 'String',
       value: certificate

--- a/lib/code-signing/private-key.ts
+++ b/lib/code-signing/private-key.ts
@@ -51,10 +51,7 @@ export class RsaPrivateKeySecret extends cdk.Construct {
    * The ARN of the secret that holds the private key.
    */
   public secretArn: string;
-  /**
-   * The VersionID of the secret that holds the private key.
-   */
-  public secretVersion: string;
+
   private secretArnLike: string;
   private masterKey?: kms.EncryptionKeyRef;
 
@@ -83,7 +80,6 @@ export class RsaPrivateKeySecret extends cdk.Construct {
     customResource.addToRolePolicy(new iam.PolicyStatement()
       .addActions('secretsmanager:CreateSecret',
                   'secretsmanager:DeleteSecret',
-                  'secretsmanager:ListSecretVersionIds',
                   'secretsmanager:UpdateSecret')
       .addResource(this.secretArnLike));
 
@@ -134,7 +130,6 @@ export class RsaPrivateKeySecret extends cdk.Construct {
 
     this.masterKey = props.secretEncryptionKey;
     this.secretArn = privateKey.getAtt('SecretArn').toString();
-    this.secretVersion = privateKey.getAtt('SecretVersionId').toString();
   }
 
   /**
@@ -181,7 +176,6 @@ export class RsaPrivateKeySecret extends cdk.Construct {
           .addResource(this.masterKey.keyArn)
           .addCondition('StringEquals', {
             'kms:ViaService': new cdk.FnConcat('secretsmanager.', new cdk.AwsRegion(), '.amazonaws.com'),
-            'kms:EncryptionContext:SecretVersionId': this.secretVersion,
           })
           .addCondition('ArnEquals', {
             'kms:EncryptionContext:SecretARN': this.secretArn,

--- a/lib/credential-pair.ts
+++ b/lib/credential-pair.ts
@@ -26,10 +26,4 @@ export interface ICredentialPair {
    * this credential pair.
    */
   readonly privatePartSecretArn: string;
-
-  /**
-   * The VersionId of the AWS SecretsManager secret that holds the private part
-   * of this credential pair.
-   */
-  readonly privatePartSecretVersionId: string;
 }

--- a/lib/pgp-secret.ts
+++ b/lib/pgp-secret.ts
@@ -69,7 +69,6 @@ export class PGPSecret extends cdk.Construct implements ICredentialPair {
   public readonly publicPartParameterArn: string;
   public readonly publicPartParameterName: string;
   public readonly privatePartSecretArn: string;
-  public readonly privatePartSecretVersionId: string;
 
   constructor(parent: cdk.Construct, name: string, props: PGPSecretProps) {
     super(parent, name);
@@ -87,7 +86,6 @@ export class PGPSecret extends cdk.Construct implements ICredentialPair {
       initialPolicy: [
         new iam.PolicyStatement()
           .addActions('secretsmanager:CreateSecret',
-                      'secretsmanager:ListSecretVersionIds',
                       'secretsmanager:UpdateSecret',
                       'secretsmanager:DeleteSecret',
                       'ssm:PutParameter',
@@ -117,7 +115,6 @@ export class PGPSecret extends cdk.Construct implements ICredentialPair {
       },
     });
     this.privatePartSecretArn = secret.getAtt('SecretArn').toString();
-    this.privatePartSecretVersionId = secret.getAtt('SecretVersionId').toString();
     this.publicPartParameterName = secret.getAtt('ParameterName').toString();
     this.publicPartParameterArn = cdk.ArnUtils.fromComponents({ service: 'ssm', resource: 'parameter', resourceName: this.publicPartParameterName });
   }


### PR DESCRIPTION
The secrets VersionId field can be used to reference a particular instance of a secret
however this makes migrating secrets to a new location (by replacing the content with
a new value) impossible, and also doesn't work great with automatic secret rotation.
Hence, removing the option to even access it.

BREAKING CHANGE: The `privateKeySecretVersion` properties are no longer available,
instead, users are advised to resort to the `AWSCURRENT` staging label.