### PR TITLE
Append / to tmpdir in test - was failing on linux

### DIFF
--- a/test/custom-resource-handlers/_rmrf.test.ts
+++ b/test/custom-resource-handlers/_rmrf.test.ts
@@ -5,7 +5,7 @@ import path = require('path');
 import _rmrf = require('../../custom-resource-handlers/src/_rmrf');
 
 test('removes a full directory', () => {
-  const dir = fs.mkdtempSync(os.tmpdir());
+  const dir = fs.mkdtempSync(os.tmpdir() + '/');
   fs.writeFileSync(path.join(dir, 'exhibit-A'), 'Exhibit A');
   return expect(_rmrf(dir).then(() => fs.existsSync(dir))).resolves.toBeFalsy();
 });


### PR DESCRIPTION
Fixed a test that was failing on linux but not mac (for some reason).

Tested on both platforms and it runs successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
