### PR TITLE
fix: pgp-secret did not store passphrase in secrets manager

### DIFF
--- a/custom-resource-handlers/src/pgp-secret.ts
+++ b/custom-resource-handlers/src/pgp-secret.ts
@@ -91,7 +91,10 @@ async function _createNewKey(event: cfn.CreateEvent | cfn.UpdateEvent, context: 
       ClientRequestToken: context.awsRequestId,
       Description: event.ResourceProperties.Description,
       KmsKeyId: event.ResourceProperties.KeyArn,
-      SecretString: keyMaterial,
+      SecretString: JSON.stringify({
+        PrivateKey: keyMaterial,
+        Passphrase: passPhrase
+      }),
     };
     const secret = event.RequestType === cfn.RequestType.CREATE
                  ? await secretsManager.createSecret({ ...secretOpts, Name: event.ResourceProperties.SecretName }).promise()

--- a/test/custom-resource-handlers/pgp-secret.test.ts
+++ b/test/custom-resource-handlers/pgp-secret.test.ts
@@ -100,7 +100,10 @@ test('Create', async () => {
       Description: event.ResourceProperties.Description,
       KmsKeyId: event.ResourceProperties.KeyArn,
       Name: event.ResourceProperties.SecretName,
-      SecretString: mockPrivateKey,
+      SecretString: JSON.stringify({
+        PrivateKey: mockPrivateKey,
+        Passphrase: passphrase.toString('base64')
+      }),
     });
   await expect(mockSSM.putParameter)
     .toBeCalledWith({


### PR DESCRIPTION
keys are created with a passphrase, and "with-signing-key.sh"
scripts expect a "Passphrase" field in the secret which should be
encoded as JSON. 

Not sure how this actually ever worked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
