### PR TITLE
feat: Move permission grant function to PGPSecret

### DIFF
--- a/lib/pgp-secret.ts
+++ b/lib/pgp-secret.ts
@@ -120,4 +120,23 @@ export class PGPSecret extends cdk.Construct implements ICredentialPair {
     this.publicPartParameterName = secret.getAtt('ParameterName').toString();
     this.publicPartParameterArn = cdk.ArnUtils.fromComponents({ service: 'ssm', resource: 'parameter', resourceName: this.publicPartParameterName });
   }
+
+  public grantRead(grantee: iam.IPrincipal): void {
+    // Secret grant, identity-based only
+    grantee.addToPolicy(new iam.PolicyStatement()
+      .addResources(this.privatePartSecretArn)
+      .addActions('secretsmanager:ListSecrets', 'secretsmanager:DescribeSecret', 'secretsmanager:GetSecretValue'));
+
+    // Key grant
+    if (this.privatePartEncryptionKey) {
+      grantee.addToPolicy(new iam.PolicyStatement()
+        .addResources(this.privatePartEncryptionKey.keyArn)
+        .addActions('kms:Decrypt'));
+
+      this.privatePartEncryptionKey.addToResourcePolicy(new iam.PolicyStatement()
+        .addAllResources()
+        .addPrincipal(grantee.principal)
+        .addActions('kms:Decrypt'));
+    }
+  }
 }

--- a/lib/signing-key.ts
+++ b/lib/signing-key.ts
@@ -64,19 +64,6 @@ export class OpenPgpKey extends cdk.Construct {
   }
 
   public grantRead(identity: iam.IPrincipal) {
-    // Secret grant, identity-based only
-    identity.addToPolicy(new iam.PolicyStatement()
-      .addResources(this.secret.privatePartSecretArn)
-      .addActions('secretsmanager:ListSecrets', 'secretsmanager:DescribeSecret', 'secretsmanager:GetSecretValue'));
-
-    // Key grant
-    identity.addToPolicy(new iam.PolicyStatement()
-      .addResources(this.key.keyArn)
-      .addActions('kms:Decrypt'));
-
-    this.key.addToResourcePolicy(new iam.PolicyStatement()
-      .addAllResources()
-      .addPrincipal(identity.principal)
-      .addActions('kms:Decrypt'));
+    return this.secret.grantRead(identity);
   }
 }


### PR DESCRIPTION
The OpenPgpKey function remains available and simply proxies through to the PGPSecret instance
it is wrapping.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
