### PR TITLE
fix: Add missing permission to PGPSecret CustomResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="2.0.1"></a>
+# [2.0.1](https://github.com/awslabs/aws-delivlib/compare/v2.0.0...v2.0.1) (2019-02-11)
+
+### Bug Fixes
+
+* Add missing permission to PGPSecret CustomResource
+
 <a name="2.0.0"></a>
 # [2.0.0](https://github.com/awslabs/aws-delivlib/compare/v1.0.0...v2.0.0) (2019-02-11)
 

--- a/lib/pgp-secret.ts
+++ b/lib/pgp-secret.ts
@@ -87,8 +87,9 @@ export class PGPSecret extends cdk.Construct implements ICredentialPair {
       initialPolicy: [
         new iam.PolicyStatement()
           .addActions('secretsmanager:CreateSecret',
-                      'secretsmanager:UpdateSecret',
                       'secretsmanager:DeleteSecret',
+                      'secretsmanager:GetSecretValue',
+                      'secretsmanager:UpdateSecret',
                       'ssm:PutParameter',
                       'ssm:DeleteParameter')
           .addAllResources(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-delivlib",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-delivlib",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/awslabs/aws-delivlib",
   "description": "A fabulous library for defining continuous pipelines for building, testing and releasing code libraries.",
   "main": "lib/index.js",


### PR DESCRIPTION
On `UPDATE`, the CustomResource needs to be able to re-read the private
key, so it is able to produce the public part of it again. This adds the
missing permission.
