### PR TITLE
fix: Don't attempt deleting OpenPGP keys' secrets

### DIFF
--- a/custom-resource-handlers/src/pgp-secret.ts
+++ b/custom-resource-handlers/src/pgp-secret.ts
@@ -61,7 +61,7 @@ async function handleEvent(event: cfn.Event, context: lambda.Context): Promise<c
           ? await _createNewKey(event, context)
           : await _updateExistingKey(event as cfn.UpdateEvent, context);
   case cfn.RequestType.DELETE:
-    return await _deleteSecret(event);
+    return { Ref: event.PhysicalResourceId };
   }
 }
 
@@ -107,13 +107,6 @@ async function _createNewKey(event: cfn.CreateEvent | cfn.UpdateEvent, context: 
   } finally {
     await _rmrf(tempDir);
   }
-}
-
-async function _deleteSecret(event: cfn.DeleteEvent): Promise<cfn.ResourceAttributes> {
-  if (event.PhysicalResourceId.startsWith('arn:') && event.ResourceProperties.ParameterName) {
-    await ssm.deleteParameter({ Name: event.ResourceProperties.ParameterName }).promise();
-  }
-  return { Ref: event.PhysicalResourceId };
 }
 
 async function _updateExistingKey(event: cfn.UpdateEvent, context: lambda.Context): Promise<ResourceAttributes> {

--- a/custom-resource-handlers/src/pgp-secret.ts
+++ b/custom-resource-handlers/src/pgp-secret.ts
@@ -110,11 +110,8 @@ async function _createNewKey(event: cfn.CreateEvent | cfn.UpdateEvent, context: 
 }
 
 async function _deleteSecret(event: cfn.DeleteEvent): Promise<cfn.ResourceAttributes> {
-  if (event.PhysicalResourceId.startsWith('arn:')) {
-    if (event.ResourceProperties.ParameterName) {
-      await ssm.deleteParameter({ Name: event.ResourceProperties.ParameterName }).promise();
-    }
-    await secretsManager.deleteSecret({ SecretId: event.PhysicalResourceId }).promise();
+  if (event.PhysicalResourceId.startsWith('arn:') && event.ResourceProperties.ParameterName) {
+    await ssm.deleteParameter({ Name: event.ResourceProperties.ParameterName }).promise();
   }
   return { Ref: event.PhysicalResourceId };
 }

--- a/lib/open-pgp-key-pair.ts
+++ b/lib/open-pgp-key-pair.ts
@@ -61,7 +61,7 @@ interface OpenPGPKeyPairProps {
 }
 
 /**
- * A PGP key that is stored in Secrets Manager
+ * A PGP key that is stored in Secrets Manager. The SecretsManager secret is retained when the resource is deleted.
  *
  * The string in secrets manager will be a JSON struct of
  *
@@ -88,7 +88,6 @@ export class OpenPGPKeyPair extends cdk.Construct implements ICredentialPair {
     fn.addToRolePolicy(new iam.PolicyStatement()
       .allow()
       .addActions('secretsmanager:CreateSecret',
-                  'secretsmanager:DeleteSecret',
                   'secretsmanager:GetSecretValue',
                   'secretsmanager:UpdateSecret')
       .addResource(cdk.Stack.find(this).formatArn({

--- a/lib/open-pgp-key-pair.ts
+++ b/lib/open-pgp-key-pair.ts
@@ -97,13 +97,11 @@ export class OpenPGPKeyPair extends cdk.Construct implements ICredentialPair {
         resourceName: `${props.secretName}-??????`
       })));
 
+    // To allow easy migration from verison that handled the SSM parameter in the custom resource
     fn.addToRolePolicy(new iam.PolicyStatement()
       .allow()
-      .addActions('ssm:PutParameter', 'ssm:DeleteParameter')
-      .addResource(cdk.Stack.find(this).formatArn({
-        service: 'ssm',
-        resource: `parameter${props.pubKeyParameterName}`,
-      })));
+      .addAction('ssm:DeleteParameter')
+      .addAllResources());
 
     if (props.encryptionKey) {
       props.encryptionKey.addToResourcePolicy(new iam.PolicyStatement()

--- a/test/custom-resource-handlers/pgp-secret.test.ts
+++ b/test/custom-resource-handlers/pgp-secret.test.ts
@@ -167,13 +167,8 @@ test('Delete', async () => {
     ...mockEventBase
   };
 
-  mockSecretsManager.deleteSecret = jest.fn().mockName('SecretsManager.deleteSecret')
-    .mockImplementation(() => ({ promise: () => Promise.resolve({}) })) as any;
-
   const { handler } = require('../../custom-resource-handlers/src/pgp-secret');
   await expect(handler(event, context)).resolves.toBe(undefined);
-  await expect(mockSecretsManager.deleteSecret)
-    .toBeCalledWith({ SecretId: secretArn });
   return expect(mockSendResponse)
     .toBeCalledWith(event,
                     cfn.Status.SUCCESS,

--- a/test/expected.json
+++ b/test/expected.json
@@ -2640,7 +2640,7 @@ Resources:
         Fn::GetAtt:
           - SingletonLambdaf25803d3054b44fc985f4860d7d6ee746203BDE6
           - Arn
-      ResourceVersion: BmJrhE3IJniqTXFb2Ow8EVjpFqUcJJcEjwztst10nzM=
+      ResourceVersion: 9vHZAAb5QYItZQp3IjvrrMycdq3qr77dTQs45NOIRy0=
       Identity: aws-cdk-dev
       Email: aws-cdk-dev+delivlib@amazon.com
       Expiry: 4y
@@ -2696,7 +2696,6 @@ Resources:
         Statement:
           - Action:
               - secretsmanager:CreateSecret
-              - secretsmanager:DeleteSecret
               - secretsmanager:GetSecretValue
               - secretsmanager:UpdateSecret
             Effect: Allow

--- a/test/expected.json
+++ b/test/expected.json
@@ -2705,16 +2705,9 @@ Resources:
                 - - "arn:"
                   - Ref: AWS::Partition
                   - :secretsmanager:us-east-1:712950704752:secret:delivlib-test/CodeSign-??????
-          - Action:
-              - ssm:PutParameter
-              - ssm:DeleteParameter
+          - Action: ssm:DeleteParameter
             Effect: Allow
-            Resource:
-              Fn::Join:
-                - ""
-                - - "arn:"
-                  - Ref: AWS::Partition
-                  - :ssm:us-east-1:712950704752:parameter/delivlib-test/CodeSign.pub
+            Resource: "*"
         Version: "2012-10-17"
       PolicyName: SingletonLambdaf25803d3054b44fc985f4860d7d6ee74ServiceRoleDefaultPolicyA8FDF5BD
       Roles:

--- a/test/open-pgp-key-pair.test.ts
+++ b/test/open-pgp-key-pair.test.ts
@@ -80,7 +80,6 @@ test('Handler has appropriate permissions', () => {
         Effect: 'Allow',
         Action: [
           'secretsmanager:CreateSecret',
-          'secretsmanager:DeleteSecret',
           'secretsmanager:GetSecretValue',
           'secretsmanager:UpdateSecret',
         ],

--- a/test/open-pgp-key-pair.test.ts
+++ b/test/open-pgp-key-pair.test.ts
@@ -90,15 +90,8 @@ test('Handler has appropriate permissions', () => {
         }
       }, {
         Effect: 'Allow',
-        Action: [
-          'ssm:PutParameter',
-          'ssm:DeleteParameter'
-        ],
-        Resource: {
-          'Fn::Join': ['',
-            ['arn:', { Ref: 'AWS::Partition' }, ':ssm:', { Ref: 'AWS::Region' }, ':', { Ref: 'AWS::AccountId' }, ':parameter/Foo']
-          ]
-        }
+        Action: 'ssm:DeleteParameter',
+        Resource: '*'
       }]
     },
     PolicyName: 'SingletonLambdaf25803d3054b44fc985f4860d7d6ee74ServiceRoleDefaultPolicyA8FDF5BD',


### PR DESCRIPTION
Since the grants on the SSM and SecretsManager API are tightened down to just the particular secrets/parameters being managed (given their names), the permission to "delete" the secret no longer exists when the resource is called if it no longer is in the stack (for the permission grant also is no longer in the stack).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
