### PR TITLE
chore: Neuter milliseconds of dates

### DIFF
--- a/change-control-lambda/lib/time-window.ts
+++ b/change-control-lambda/lib/time-window.ts
@@ -62,6 +62,9 @@ function containingEventsWithMargin(events: Events, date: Date, advanceMarginSec
  * @returns true if `left` and `right` overlap
  */
 function overlaps(left: { start: Date, end: Date }, right: { start: Date, end: Date }): boolean {
+  // Neutering out the milliseconds portions, so they don't interfere
+  [left.start, left.end, right.start, right.end].forEach(d => d.setMilliseconds(0));
+
   return isBetween(right.start, left.start, left.end)
     || isBetween(right.end, left.start, left.end)
     || isBetween(left.start, right.start, right.end)

--- a/pipeline/delivlib.ts
+++ b/pipeline/delivlib.ts
@@ -27,7 +27,7 @@ export class DelivLibPipelineStack extends cdk.Stack {
         version: '0.2',
         phases: {
           install: {
-            commands: [ 'npm install' ]
+            commands: [ 'npm ci' ]
           },
           build: {
             commands: [


### PR DESCRIPTION
Suspecting differences in how the milliseconds portion of parsed dates
get initialized when no milliseconds portion is provided in the parsed
string, attempting to zero out the milliseconds explicitly in an attempt
to fix breaking tests that I fail to reproduce locally.