### PR TITLE
The Python language binding for JSII requires that wheel be installed.

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -288,7 +288,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
 # https://github.com/docker-library/python/pull/143#issuecomment-241032683
 	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
-        && pip install awscli==1.* boto3 pipenv virtualenv --no-cache-dir \
+        && pip install awscli==1.* boto3 pipenv virtualenv wheel --no-cache-dir \
 # then we use "pip list" to ensure we don't have more than one pip version installed
 # https://github.com/docker-library/python/pull/100
 	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \


### PR DESCRIPTION
*Issue #79*

*Description of changes:*

Modifies the Dockerfile for the superchain image to `pip install wheel`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.