### PR TITLE
feat(s3): make S3 publisher idempotent

### DIFF
--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -363,7 +363,7 @@ export class PublishToS3 extends cdk.Construct implements IPublisher {
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_BASE),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_8_11_0),
       scriptDirectory: path.join(__dirname, 'publishing', 's3'),
       entrypoint: 'publish.sh',
       environment: {

--- a/lib/publishing/s3/publish.sh
+++ b/lib/publishing/s3/publish.sh
@@ -10,4 +10,37 @@ args=""
 if ${PUBLIC:-false}; then
   args="--acl public-read"
 fi
-aws s3 sync . $BUCKET_URL $args
+
+idempotency_token=""
+
+# See if there's a file with publishing commands
+if [[ -f s3-publishing.json ]]; then
+    echo "Found publishing instructions"
+    cat s3-publishing.json
+
+    idempotency_token=$(node -pe "require('./s3-publishing.json')['idempotency-token'] || ''")
+
+    # We don't want to upload this file
+    args="$args --exclude s3-publishing.json"
+fi
+
+if [[ "${idempotency_token:-}" != "" ]]; then
+    echo "Idempotency token: $idempotency_token"
+
+    aws s3 ls $BUCKET_URL/$idempotency_token > /dev/null && {
+        echo "Token found, stopping."
+        exit 0
+    } || {
+        echo "Idempotency token not found, continuing."
+    }
+fi
+
+# Do the copy
+echo "Starting the upload to $BUCKET_URL"
+echo "(Args: $args)"
+aws s3 cp --recursive . $BUCKET_URL $args
+
+if [[ "${idempotency_token:-}" != "" ]]; then
+    echo "Writing idempotency token..."
+    echo 1 | aws s3 cp - $BUCKET_URL/$idempotency_token
+fi


### PR DESCRIPTION
S3 publisher can be made idempotent by giving it a unique token for
every version in a config file. Already-published revisions will not be
published again.

Switch to 's3 cp' instead of 's3 sync' to avoid reading the server-side
files; no need to do any syncing, we'll either do a full copy of all
files or no files.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
