### PR TITLE
feat: shellable alarm configuration

### DIFF
--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -65,6 +65,24 @@ export interface ShellableOptions {
    * @default No output artifact
    */
   artifactDirectory?: string;
+
+  /**
+   * Alarm period (in seconds)
+   * @default 300 (5 minutes)
+   */
+  alarmPeriodSec?: number;
+
+  /**
+   * Alarm threshold.
+   * @default 1
+   */
+  alarmThreshold?: number;
+
+  /**
+   * Alarm evaluation periods.
+   * @default 1
+   */
+  alarmEvaluationPeriods?: number;
 }
 
 /**
@@ -217,10 +235,10 @@ export class Shellable extends cdk.Construct {
     }
 
     this.alarm = new cloudwatch.Alarm(this, `Alarm`, {
-      metric: this.project.metricFailedBuilds({ periodSec: 300 }),
-      threshold: 1,
+      metric: this.project.metricFailedBuilds({ periodSec: props.alarmPeriodSec || 300 }),
+      threshold: props.alarmThreshold || 1,
       comparisonOperator: cloudwatch.ComparisonOperator.GreaterThanOrEqualToThreshold,
-      evaluationPeriods: 1,
+      evaluationPeriods: props.alarmEvaluationPeriods || 1,
       treatMissingData: cloudwatch.TreatMissingData.Ignore
     });
   }

--- a/test/shellable.test.ts
+++ b/test/shellable.test.ts
@@ -69,3 +69,36 @@ test('assume role not supported on windows', () => {
     }
   })).toThrow('assumeRole is not supported on Windows');
 });
+
+test('alarm options - defaults', () => {
+  const stack = new Stack();
+
+  new Shellable(stack, 'MyShellable', {
+    scriptDirectory: path.join(__dirname, 'delivlib-tests/linux'),
+    entrypoint: 'test.sh',
+  });
+
+  assert(stack).to(haveResource('AWS::CloudWatch::Alarm', {
+    EvaluationPeriods: 1,
+    Threshold: 1,
+    Period: 300
+  }));
+});
+
+test('alarm options - custom', () => {
+  const stack = new Stack();
+
+  new Shellable(stack, 'MyShellable', {
+    scriptDirectory: path.join(__dirname, 'delivlib-tests/linux'),
+    entrypoint: 'test.sh',
+    alarmEvaluationPeriods: 2,
+    alarmThreshold: 5,
+    alarmPeriodSec: 60 * 60
+  });
+
+  assert(stack).to(haveResource('AWS::CloudWatch::Alarm', {
+    EvaluationPeriods: 2,
+    Threshold: 5,
+    Period: 3600
+  }));
+});


### PR DESCRIPTION
allow customizing failure alarm period, threshold and evaluation periods.

related: awslabs/cdk-ops#329

