### PR TITLE
 feat: multiple artifacts for GitHub and Shellable 

### DIFF
--- a/lib/build-spec.ts
+++ b/lib/build-spec.ts
@@ -1,0 +1,163 @@
+import { mapValues, noUndefined } from "./util";
+
+/**
+ * Class to model a buildspec version 0.2
+ */
+export class BuildSpec {
+  public static literal(struct: BuildSpecStruct) {
+    return new BuildSpec(struct);
+  }
+
+  public static simple(props: SimpleBuildSpecProps) {
+    if (props.secondaryArtifactDirectories !== undefined && props.primaryArtifactDirectory === undefined) {
+      // FIXME: We should treat all artifacts the same and the primary at render time, otherwise
+      // merging gets too complicated for no good reason.
+      throw new Error('Secondary artifacts also require a primary artifact');
+    }
+
+    return new BuildSpec({
+      version: "0.2",
+      phases: noUndefined({
+        pre_build: props.preBuild !== undefined ? { commands: props.preBuild } : undefined,
+        build: props.build !== undefined ? { commands: props.build } : undefined,
+      }),
+      artifacts: props.primaryArtifactDirectory !== undefined ? noUndefined({
+        "base-directory": props.primaryArtifactDirectory,
+        "files": ['**/*'],
+        "secondary-artifacts": props.secondaryArtifactDirectories !== undefined
+            ? mapValues(props.secondaryArtifactDirectories, d => ({ "base-directory": d, "files": ['**/*'] }))
+            : undefined,
+      }) : undefined,
+    });
+  }
+
+  public static empty() {
+    return new BuildSpec({ version: "0.2" });
+  }
+
+  private constructor(private readonly spec: BuildSpecStruct) {
+  }
+
+  public merge(other: BuildSpec, options: MergeOptions = {}): BuildSpec {
+    return new BuildSpec({
+      "version": "0.2",
+      "run-as": mergeObj(this.spec["run-as"], other.spec["run-as"], equalObjects),
+      "env": mergeObj(this.spec.env, other.spec.env, (a, b) => ({
+        "parameter-store": mergeDict(a["parameter-store"], b["parameter-store"], equalObjects),
+        "variables": mergeDict(a.variables, b.variables, equalObjects)
+      })),
+      "phases": mergeDict(this.spec.phases, other.spec.phases, (a, b) => ({
+        "run-as": mergeObj(this.spec["run-as"], other.spec["run-as"], equalObjects),
+        "commands": mergeList(a.commands, b.commands)!,
+        "finally": mergeList(a.finally, b.finally),
+      })),
+      "artifacts": mergeObj(this.spec.artifacts, other.spec.artifacts, mergeArtifacts),
+      "cache": mergeObj(this.spec.cache, other.spec.cache, (a, b) => ({
+        paths: mergeList(a.paths, b.paths)!
+      }))
+    });
+
+    function mergeArtifacts(a: PrimaryArtifactStruct, b: PrimaryArtifactStruct): PrimaryArtifactStruct {
+      if (!options.renamePrimaryArtifact) {
+        throw new Error('Right-hand-side has primary artifact. Must supply renamePrimaryArtifact.');
+      }
+
+      const artifacts = Object.assign({}, a["secondary-artifacts"] || {});
+      if (options.renamePrimaryArtifact in artifacts) {
+        throw new Error(`There is already an artifact with name ${options.renamePrimaryArtifact}`);
+      }
+      artifacts[options.renamePrimaryArtifact] = Object.assign({}, b, { 'secondary-artifacts': undefined });
+      for (const [k, v] of Object.entries(b["secondary-artifacts"] || {})) {
+        if (k in artifacts) {
+          throw new Error(`There is already an artifact with name ${k}`);
+        }
+        artifacts[k] = v;
+      }
+      return Object.assign({}, a, { 'secondary-artifacts': artifacts });
+    }
+
+    function equalObjects(a: string, b: string) {
+      if (a !== b) {
+        throw new Error(`Can't merge two different values for the same key: ${JSON.stringify(a)}, ${JSON.stringify(b)}`);
+      }
+      return b;
+    }
+
+    function mergeObj<T>(a: T | undefined, b: T | undefined, fn: (a: T, b: T) => T): T | undefined {
+      if (a === undefined) { return b; }
+      if (b === undefined) { return a; }
+      return fn(a, b);
+    }
+
+    function mergeDict<T>(as: {[k: string]: T} | undefined, bs: {[k: string]: T} | undefined, fn: (a: T, b: T) => T) {
+      return mergeObj(as, bs, (a, b) => {
+        const ret = Object.assign({}, a);
+        for (const [k, v] of Object.entries(b)) {
+          if (ret[k]) {
+            ret[k] = fn(ret[k], v);
+          } else {
+            ret[k] = v;
+          }
+        }
+        return ret;
+      });
+    }
+
+    function mergeList<T>(as: T[] | undefined, bs: T[] | undefined): T[] | undefined {
+      return mergeObj(as, bs, (a, b) => a.concat(b));
+    }
+  }
+
+  public render(): BuildSpecStruct {
+    return this.spec;
+  }
+}
+
+export interface MergeOptions {
+  /**
+   * Rename the primary artifact on the right-hand-side of the merge operation, if present
+   */
+  renamePrimaryArtifact?: string;
+}
+
+export interface SimpleBuildSpecProps {
+  preBuild?: string[];
+  build?: string[];
+  primaryArtifactDirectory?: string;
+  secondaryArtifactDirectories?: {[name: string]: string};
+}
+
+export interface BuildSpecStruct {
+  version: '0.2';
+  'run-as'?: string;
+  env?: EnvStruct;
+  phases?: {[key: string]: PhaseStruct };
+  artifacts?: PrimaryArtifactStruct;
+  cache?: CacheStruct;
+}
+
+export interface EnvStruct {
+  variables?: {[key: string]: string};
+  'parameter-store'?: {[key: string]: string};
+}
+
+export interface PhaseStruct {
+  'run-as'?: string;
+  commands: string[];
+  finally?: string[];
+}
+
+export interface ArtifactStruct {
+  files: string[];
+  name?: string;
+  'base-directory'?: string;
+  'discard-paths'?: 'yes' | 'no';
+}
+
+export interface PrimaryArtifactStruct extends ArtifactStruct {
+  'secondary-artifacts'?: {[key: string]: ArtifactStruct};
+}
+
+export interface CacheStruct {
+  paths: string[];
+}

--- a/lib/build-spec.ts
+++ b/lib/build-spec.ts
@@ -38,6 +38,10 @@ export class BuildSpec {
   private constructor(private readonly spec: BuildSpecStruct) {
   }
 
+  public get additionalArtifactNames(): string[] {
+    return Object.keys(this.spec.artifacts && this.spec.artifacts["secondary-artifacts"] || {});
+  }
+
   public merge(other: BuildSpec, options: MergeOptions = {}): BuildSpec {
     return new BuildSpec({
       "version": "0.2",

--- a/lib/build-spec.ts
+++ b/lib/build-spec.ts
@@ -115,7 +115,12 @@ export class BuildSpec {
 
 export interface MergeOptions {
   /**
-   * Rename the primary artifact on the right-hand-side of the merge operation, if present
+   * Rename the primary artifact on the right-hand-side of the merge operation.
+   *
+   * Required if the RHS BuildSpec contains a primary artifact (it will become
+   * a secondery artifact of the merged BuildSpec).
+   *
+   * @default - No renaming
    */
   renamePrimaryArtifact?: string;
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './canary';
+export * from './build-spec';
 export * from './code-signing';
 export * from './credential-pair';
 export * from './open-pgp-key-pair';

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -393,4 +393,9 @@ export interface AddShellableOptions extends ShellableProps {
    * @default Build output artifact
    */
   inputArtifact?: cpipelineapi.Artifact;
+
+  /**
+   * Additional output artifact names
+   */
+  additionalOutputArtifactNames?: string[];
 }

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -100,6 +100,15 @@ export interface PipelineProps {
    * @default no limit
    */
   concurrency?: number;
+
+  /**
+   * Set the default dryRun for all publishing steps
+   *
+   * (Can still be changed when adding a step).
+   *
+   * @default false
+   */
+  dryRun?: boolean;
 }
 
 /**
@@ -117,12 +126,14 @@ export class Pipeline extends cdk.Construct {
 
   private readonly concurrency?: number;
   private readonly repo: IRepo;
+  private readonly dryRun: boolean;
 
   constructor(parent: cdk.Construct, name: string, props: PipelineProps) {
     super(parent, name);
 
     this.concurrency = props.concurrency;
     this.repo = props.repo;
+    this.dryRun = !!props.dryRun;
 
     this.pipeline = new cpipeline.Pipeline(this, 'BuildPipeline', {
       pipelineName: props.pipelineName,
@@ -220,44 +231,51 @@ export class Pipeline extends cdk.Construct {
 
   public publishToNpm(options: publishing.PublishToNpmProjectProps) {
     this.addPublish(new publishing.PublishToNpmProject(this, 'Npm', {
-      dryRun: false,
+      dryRun: this.dryRun,
       ...options
     }));
   }
 
   public publishToMaven(options: publishing.PublishToMavenProjectProps) {
     this.addPublish(new publishing.PublishToMavenProject(this, 'Maven', {
-      dryRun: false,
+      dryRun: this.dryRun,
       ...options
     }));
   }
 
   public publishToNuGet(options: publishing.PublishToNuGetProjectProps) {
     this.addPublish(new publishing.PublishToNuGetProject(this, 'NuGet', {
-      dryRun: false,
+      dryRun: this.dryRun,
       ...options
     }));
   }
 
   public publishToGitHubPages(options: publishing.PublishDocsToGitHubProjectProps) {
     this.addPublish(new publishing.PublishDocsToGitHubProject(this, 'GitHubPages', {
-      dryRun: false,
+      dryRun: this.dryRun,
       ...options,
     }));
   }
 
   public publishToGitHub(options: publishing.PublishToGitHubProps) {
     this.addPublish(new publishing.PublishToGitHub(this, 'GitHub', {
-      dryRun: false,
+      dryRun: this.dryRun,
       ...options
     }));
   }
 
   public publishToPyPI(options: publishing.PublishToPyPiProps) {
     this.addPublish(new publishing.PublishToPyPi(this, 'PyPI', {
-      dryRun: false,
+      dryRun: this.dryRun,
       ...options
     }));
+  }
+
+  public publishToS3(id: string, options: publishing.PublishToS3Props & AddPublishOptions) {
+    this.addPublish(new publishing.PublishToS3(this, id, {
+      dryRun: this.dryRun,
+      ...options
+  }), options);
   }
 
   /**

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -393,9 +393,4 @@ export interface AddShellableOptions extends ShellableProps {
    * @default Build output artifact
    */
   inputArtifact?: cpipelineapi.Artifact;
-
-  /**
-   * Additional output artifact names
-   */
-  additionalOutputArtifactNames?: string[];
 }

--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -11,6 +11,7 @@ import permissions = require('./permissions');
 import { AddToPipelineOptions, IPublisher } from './pipeline';
 import { WritableGitHubRepo } from './repo';
 import { LinuxPlatform, Shellable } from './shellable';
+import { noUndefined } from './util';
 
 export interface PublishToMavenProjectProps {
   /**
@@ -326,7 +327,7 @@ export class PublishToGitHub extends cdk.Construct implements IPublisher {
       platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_10_1_0),
       scriptDirectory: path.join(__dirname, 'publishing', 'github'),
       entrypoint: 'publish.sh',
-      environment: {
+      environment: noUndefined({
         BUILD_MANIFEST: props.buildManifestFileName || './build.json',
         CHANGELOG: props.changelogFileName || './CHANGELOG.md',
         SIGNING_KEY_ARN: props.signingKey.credential.secretArn,
@@ -335,9 +336,9 @@ export class PublishToGitHub extends cdk.Construct implements IPublisher {
         GITHUB_REPO: props.githubRepo.repo,
         FOR_REAL: forReal,
         // Transmit the names of the secondary sources to the shell script (for easier iteration)
-        SECONDARY_SOURCE_NAMES: props.additionalInputArtifacts ? props.additionalInputArtifacts.map(a => a.name).join(' ') : '',
-        SIGN_ADDITIONAL_ARTIFACTS: props.signAdditionalArtifacts !== false ? 'true' : 'false'
-      }
+        SECONDARY_SOURCE_NAMES: props.additionalInputArtifacts ? props.additionalInputArtifacts.map(a => a.name).join(' ') : undefined,
+        SIGN_ADDITIONAL_ARTIFACTS: props.additionalInputArtifacts && props.signAdditionalArtifacts !== false ? 'true' : undefined,
+      })
     });
 
     // allow script to read the signing key

--- a/lib/publishing/github/publish.sh
+++ b/lib/publishing/github/publish.sh
@@ -70,4 +70,15 @@ fi
 
 heading "Creating release"
 ls ${workdir}
-node ${scriptdir}/create-release.js ${workdir}/*
+
+if $FOR_REAL; then
+    node ${scriptdir}/create-release.js ${workdir}/*
+else
+    echo "==========================================="
+    echo "            🏜️ DRY-RUN MODE 🏜️"
+    echo
+    echo "Skipping the actual publishing step."
+    echo
+    echo "Set FOR_REAL=true to do it!"
+    echo "==========================================="
+fi

--- a/lib/publishing/github/publish.sh
+++ b/lib/publishing/github/publish.sh
@@ -32,8 +32,8 @@ prepare_artifacts_in_current_dir() {
     echo "version: ${version}"
 
     # --------------------------------------------------------------------------------------------------
-    echo "Preparing .zip archive"
     local archive="${workdir}/${name}-${version}.zip"
+    echo "Preparing .zip archive: ${archive}"
 
     [[ ! -f ${archive} ]] || {
         echo "File already created by a different artifact: $archive" >&2

--- a/lib/publishing/github/publish.sh
+++ b/lib/publishing/github/publish.sh
@@ -59,7 +59,8 @@ prepare_artifacts_in_current_dir true
 if [[ "${SECONDARY_SOURCE_NAMES:-}" != "" ]]; then
     for source_name in ${SECONDARY_SOURCE_NAMES}; do
         heading "Additional Source: $source_name"
-        (cd ${CODEBUILD_SRC_DIR_${source_name}} && prepare_artifacts_in_current_dir ${SIGN_ADDITIONAL_ARTIFACTS:-false})
+        source_dir_var=CODEBUILD_SRC_DIR_${source_name}
+        (cd ${!source_dir_var} && prepare_artifacts_in_current_dir ${SIGN_ADDITIONAL_ARTIFACTS:-false})
     done
 fi
 

--- a/lib/publishing/github/publish.sh
+++ b/lib/publishing/github/publish.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 scriptdir="$(cd $(dirname $0) && pwd)"
+workdir="$(mktemp -d)"
 
 heading() {
     echo
@@ -13,36 +14,59 @@ read_json_field() {
     node -e "process.stdout.write(require('./$1').$2)"
 }
 
-build_manifest="${BUILD_MANIFEST:-"./build.json"}"
+# prepare_artifacts_in_current_dir TRY_TO_SIGN
+prepare_artifacts_in_current_dir() {
+    echo "dir:" $(pwd)
+    local build_manifest="${BUILD_MANIFEST:-"./build.json"}"
 
-if [ ! -f "${build_manifest}" ]; then
-    echo "${build_manifest} file not found. should include the fields: 'name', 'version' and 'commit' (did you set BUILD_MANIFEST?)"
-    exit 1
+    if [ ! -f "${build_manifest}" ]; then
+        echo "${build_manifest} file not found. should include the fields: 'name', 'version' and 'commit' (did you set BUILD_MANIFEST?)" >&2
+        exit 1
+    fi
+
+    local version="$(read_json_field "${build_manifest}" version)"
+    local name="$(read_json_field "${build_manifest}" name)"
+
+    # --------------------------------------------------------------------------------------------------
+    echo "name: ${name}"
+    echo "version: ${version}"
+
+    # --------------------------------------------------------------------------------------------------
+    echo "Preparing .zip archive"
+    local archive="${workdir}/${name}-${version}.zip"
+
+    [[ ! -f ${archive} ]] || {
+        echo "File already created by a different artifact: $archive" >&2
+        echo "(Did you remember to create a different ${build_manifest} for every artifact?)" >&2
+        exit 1
+    }
+    zip -y -r ${archive} .
+
+    # --------------------------------------------------------------------------------------------------
+    if $1; then
+        echo "Signing .zip archive"
+        chmod +x ${scriptdir}/with-signing-key.sh
+        chmod +x ${scriptdir}/sign-files.sh
+        ${scriptdir}/with-signing-key.sh ${scriptdir}/sign-files.sh ${archive}
+    fi
+}
+
+# --------------------------------------------------------------------------------------------------
+
+heading "Primary Source"
+prepare_artifacts_in_current_dir true
+
+if [[ "${SECONDARY_SOURCE_NAMES:-}" != "" ]]; then
+    for source_name in ${SECONDARY_SOURCE_NAMES}; do
+        heading "Additional Source: $source_name"
+        (cd ${CODEBUILD_SRC_DIR_${source_name}} && prepare_artifacts_in_current_dir ${SIGN_ADDITIONAL_ARTIFACTS:-true})
+    done
 fi
 
-version="$(read_json_field "${build_manifest}" version)"
-name="$(read_json_field "${build_manifest}" name)"
 
+# --------------------------------------------------------------------------------------------------
 # install npm deps
 (cd ${scriptdir} && npm i)
 
-# --------------------------------------------------------------------------------------------------
-heading "Build metadata"
-echo "name: ${name}"
-echo "version: ${version}"
-
-# --------------------------------------------------------------------------------------------------
-heading "Preparing .zip archive"
-workdir="$(mktemp -d)"
-archive="${workdir}/${name}-${version}.zip"
-zip -y -r ${archive} .
-
-# --------------------------------------------------------------------------------------------------
-heading "Signing .zip archive"
-chmod +x ${scriptdir}/with-signing-key.sh
-chmod +x ${scriptdir}/sign-files.sh
-${scriptdir}/with-signing-key.sh ${scriptdir}/sign-files.sh ${archive}
-
-# --------------------------------------------------------------------------------------------------
 heading "Creating release"
 node ${scriptdir}/create-release.js ${workdir}/*

--- a/lib/publishing/github/publish.sh
+++ b/lib/publishing/github/publish.sh
@@ -69,4 +69,5 @@ fi
 (cd ${scriptdir} && npm i)
 
 heading "Creating release"
+ls ${workdir}
 node ${scriptdir}/create-release.js ${workdir}/*

--- a/lib/publishing/github/publish.sh
+++ b/lib/publishing/github/publish.sh
@@ -59,7 +59,7 @@ prepare_artifacts_in_current_dir true
 if [[ "${SECONDARY_SOURCE_NAMES:-}" != "" ]]; then
     for source_name in ${SECONDARY_SOURCE_NAMES}; do
         heading "Additional Source: $source_name"
-        (cd ${CODEBUILD_SRC_DIR_${source_name}} && prepare_artifacts_in_current_dir ${SIGN_ADDITIONAL_ARTIFACTS:-true})
+        (cd ${CODEBUILD_SRC_DIR_${source_name}} && prepare_artifacts_in_current_dir ${SIGN_ADDITIONAL_ARTIFACTS:-false})
     done
 fi
 

--- a/lib/publishing/s3/publish.sh
+++ b/lib/publishing/s3/publish.sh
@@ -38,9 +38,20 @@ fi
 # Do the copy
 echo "Starting the upload to $BUCKET_URL"
 echo "(Args: $args)"
-aws s3 cp --recursive . $BUCKET_URL $args
 
-if [[ "${idempotency_token:-}" != "" ]]; then
-    echo "Writing idempotency token..."
-    echo 1 | aws s3 cp - $BUCKET_URL/$idempotency_token
+if $FOR_REAL; then
+    aws s3 cp --recursive . $BUCKET_URL $args
+
+    if [[ "${idempotency_token:-}" != "" ]]; then
+        echo "Writing idempotency token..."
+        echo 1 | aws s3 cp - $BUCKET_URL/$idempotency_token
+    fi
+else
+    echo "==========================================="
+    echo "            🏜️ DRY-RUN MODE 🏜️"
+    echo
+    echo "Skipping the actual publishing step."
+    echo
+    echo "Set FOR_REAL=true to do it!"
+    echo "==========================================="
 fi

--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -189,7 +189,7 @@ export class Shellable extends cdk.Construct {
       path: props.scriptDirectory
     });
 
-    this.outputArtifactName = `${this.node.id}_Artifact`;
+    this.outputArtifactName = `Artifact_${this.node.uniqueId}`;
     if (this.outputArtifactName.length > 100) {
       throw new Error(`Whoops, too long: ${this.outputArtifactName}`);
     }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -50,3 +50,21 @@ export function renderEnvironmentVariables(env?: { [key: string]: string }) {
   }
   return out;
 }
+
+export function noUndefined<T>(xs: Partial<T>): {[k in keyof T]: T[k]} {
+  const ret: any = {};
+  for (const [k, v] of Object.entries(xs)) {
+    if (v !== undefined) {
+      ret[k] = v;
+    }
+  }
+  return ret;
+}
+
+export function mapValues<T, U>(xs: {[key: string]: T}, fn: (x: T) => U): {[key: string]: U} {
+  const ret: {[key: string]: U} = {};
+  for (const [k, v] of Object.entries(xs)) {
+    ret[k] = fn(v);
+  }
+  return ret;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3156,8 +3156,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3178,14 +3177,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3200,20 +3197,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3330,8 +3324,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3343,7 +3336,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3358,7 +3350,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3366,14 +3357,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3392,7 +3381,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3473,8 +3461,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3486,7 +3473,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3572,8 +3558,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3609,7 +3594,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3629,7 +3613,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3673,14 +3656,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/test/build-spec.test.ts
+++ b/test/build-spec.test.ts
@@ -1,0 +1,66 @@
+import delivlib = require('../lib');
+
+test('buildspec single artifact goes to "artifacts"', () => {
+  const bs = delivlib.BuildSpec.simple({
+    build: ['echo hello > foo/file.txt'],
+    artifactDirectory: 'foo'
+  });
+
+  const rendered = bs.render();
+
+  expect(rendered).toEqual({
+    artifacts: {
+      "base-directory": "foo",
+      "files": [
+        "**/*",
+      ],
+    },
+    phases: {
+      build: {
+        commands: [
+          "echo hello > foo/file.txt",
+        ],
+      },
+    },
+    version: "0.2",
+  });
+});
+
+test('buildspec multiple artifacts all go into "secondary-artifacts"', () => {
+  const bs = delivlib.BuildSpec.simple({
+    build: ['echo hello > foo/file.txt'],
+    artifactDirectory: 'foo',
+    additionalArtifactDirectories: {
+      artifact2: 'boo',
+    }
+  });
+
+  const rendered = bs.render({ primaryArtifactName: 'primrose' });
+
+  expect(rendered).toEqual({
+    artifacts: {
+      "secondary-artifacts": {
+        primrose: {
+          "base-directory": "foo",
+          "files": [
+            "**/*",
+          ],
+        },
+        artifact2: {
+          "base-directory": "boo",
+          "files": [
+            "**/*",
+          ],
+        }
+      }
+    },
+    phases: {
+      build: {
+        commands: [
+          "echo hello > foo/file.txt",
+        ],
+      },
+    },
+    version: "0.2",
+  });
+});

--- a/test/delivlib-tests/linux/void.sh
+++ b/test/delivlib-tests/linux/void.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+echo ALL GOOD

--- a/test/expected.json
+++ b/test/expected.json
@@ -82,6 +82,15 @@ Resources:
             Effect: Allow
             Resource:
               Fn::GetAtt:
+                - CodeCommitPipelineGenerateTwoArtifactsA9DAD33B
+                - Arn
+          - Action:
+              - codebuild:BatchGetBuilds
+              - codebuild:StartBuild
+              - codebuild:StopBuild
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
                 - CodeCommitPipelineNpm0D31AEFC
                 - Arn
           - Action:
@@ -191,7 +200,7 @@ Resources:
                 - Name: Artifact_delivlibtestCodeCommitPipelineBuildProjectBuildEB1D42D1
               Name: TestHelloLinux
               OutputArtifacts:
-                - Name: Artifact_delivlibtestCodeCommitPipelineHelloLinuxTestHelloLinux477C71C4
+                - Name: Artifact_delivlibtestCodeCommitPipelineHelloLinux01786D9D
               RunOrder: 1
             - ActionTypeId:
                 Category: Build
@@ -205,7 +214,7 @@ Resources:
                 - Name: Artifact_delivlibtestCodeCommitPipelineBuildProjectBuildEB1D42D1
               Name: TestHelloWindows
               OutputArtifacts:
-                - Name: Artifact_delivlibtestCodeCommitPipelineHelloWindowsTestHelloWindowsA38892AA
+                - Name: Artifact_delivlibtestCodeCommitPipelineHelloWindowsDD89E92A
               RunOrder: 1
             - ActionTypeId:
                 Category: Build
@@ -219,7 +228,22 @@ Resources:
                 - Name: Artifact_delivlibtestCodeCommitPipelineBuildProjectBuildEB1D42D1
               Name: TestAssumeRole
               OutputArtifacts:
-                - Name: Artifact_delivlibtestCodeCommitPipelineAssumeRoleTestAssumeRoleED3B2461
+                - Name: Artifact_delivlibtestCodeCommitPipelineAssumeRole8CA58C9F
+              RunOrder: 1
+            - ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: "1"
+              Configuration:
+                ProjectName:
+                  Ref: CodeCommitPipelineGenerateTwoArtifactsA9DAD33B
+              InputArtifacts:
+                - Name: Artifact_delivlibtestCodeCommitPipelineBuildProjectBuildEB1D42D1
+              Name: ActionGenerateTwoArtifacts
+              OutputArtifacts:
+                - Name: Artifact_delivlibtestCodeCommitPipelineGenerateTwoArtifacts54497DAA
+                - Name: artifact2
               RunOrder: 1
           Name: Test
         - Actions:
@@ -273,8 +297,11 @@ Resources:
               Configuration:
                 ProjectName:
                   Ref: CodeCommitPipelineGitHub0797840C
+                PrimarySource: Artifact_delivlibtestCodeCommitPipelineBuildProjectBuildEB1D42D1
               InputArtifacts:
                 - Name: Artifact_delivlibtestCodeCommitPipelineBuildProjectBuildEB1D42D1
+                - Name: Artifact_delivlibtestCodeCommitPipelineGenerateTwoArtifacts54497DAA
+                - Name: artifact2
               Name: GitHubPublish
               OutputArtifacts:
                 - Name: Artifact_delivlibtestCodeCommitPipelineGitHubGitHubPublish9C2DACED
@@ -1248,6 +1275,186 @@ Resources:
       TreatMissingData: ignore
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/AssumeRole/Alarm/Resource
+  CodeCommitPipelineGenerateTwoArtifactsRole91D2CDCA:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: "2012-10-17"
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/GenerateTwoArtifacts/Resource/Role/Resource
+  CodeCommitPipelineGenerateTwoArtifactsRoleDefaultPolicy770BE7EA:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - :logs:us-east-1:712950704752:log-group:/aws/codebuild/
+                    - Ref: CodeCommitPipelineGenerateTwoArtifactsA9DAD33B
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - :logs:us-east-1:712950704752:log-group:/aws/codebuild/
+                    - Ref: CodeCommitPipelineGenerateTwoArtifactsA9DAD33B
+                    - :*
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":s3:::"
+                    - Ref: CodeCommitPipelineGenerateTwoArtifactsScriptDirectoryS3BucketE058B7EF
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":s3:::"
+                    - Ref: CodeCommitPipelineGenerateTwoArtifactsScriptDirectoryS3BucketE058B7EF
+                    - /
+                    - Fn::Select:
+                        - 0
+                        - Fn::Split:
+                            - "||"
+                            - Ref: CodeCommitPipelineGenerateTwoArtifactsScriptDirectoryS3VersionKeyD775EF3D
+                    - "*"
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+              - s3:DeleteObject*
+              - s3:PutObject*
+              - s3:Abort*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - CodeCommitPipelineBuildPipelineArtifactsBucketED2813B3
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - CodeCommitPipelineBuildPipelineArtifactsBucketED2813B3
+                        - Arn
+                    - /*
+        Version: "2012-10-17"
+      PolicyName: CodeCommitPipelineGenerateTwoArtifactsRoleDefaultPolicy770BE7EA
+      Roles:
+        - Ref: CodeCommitPipelineGenerateTwoArtifactsRole91D2CDCA
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/GenerateTwoArtifacts/Resource/Role/DefaultPolicy/Resource
+  CodeCommitPipelineGenerateTwoArtifactsA9DAD33B:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_MEDIUM
+        EnvironmentVariables:
+          - Name: SCRIPT_S3_BUCKET
+            Type: PLAINTEXT
+            Value:
+              Ref: CodeCommitPipelineGenerateTwoArtifactsScriptDirectoryS3BucketE058B7EF
+          - Name: SCRIPT_S3_KEY
+            Type: PLAINTEXT
+            Value:
+              Fn::Join:
+                - ""
+                - - Fn::Select:
+                      - 0
+                      - Fn::Split:
+                          - "||"
+                          - Ref: CodeCommitPipelineGenerateTwoArtifactsScriptDirectoryS3VersionKeyD775EF3D
+                  - Fn::Select:
+                      - 1
+                      - Fn::Split:
+                          - "||"
+                          - Ref: CodeCommitPipelineGenerateTwoArtifactsScriptDirectoryS3VersionKeyD775EF3D
+        Image: aws/codebuild/ubuntu-base:14.04
+        PrivilegedMode: false
+        Type: LINUX_CONTAINER
+      ServiceRole:
+        Fn::GetAtt:
+          - CodeCommitPipelineGenerateTwoArtifactsRole91D2CDCA
+          - Arn
+      Source:
+        BuildSpec: >-
+          {
+            "version": "0.2",
+            "phases": {
+              "pre_build": {
+                "commands": [
+                  "echo \"Downloading scripts from s3://${SCRIPT_S3_BUCKET}/${SCRIPT_S3_KEY}\"",
+                  "aws s3 cp s3://${SCRIPT_S3_BUCKET}/${SCRIPT_S3_KEY} /tmp",
+                  "mkdir -p /tmp/scriptdir",
+                  "unzip /tmp/$(basename $SCRIPT_S3_KEY) -d /tmp/scriptdir"
+                ]
+              },
+              "build": {
+                "commands": [
+                  "export SCRIPT_DIR=/tmp/scriptdir",
+                  "echo \"Running void.sh\"",
+                  "/bin/bash /tmp/scriptdir/void.sh",
+                  "mkdir -p output1 output2",
+                  "echo '{\"name\": \"output1\", \"version\": \"1.2.3\", \"commit\": \"abcdef\"}' > output1/build.json",
+                  "echo '{\"name\": \"output2\", \"version\": \"1.2.3\", \"commit\": \"abcdef\"}' > output2/build.json"
+                ]
+              }
+            },
+            "artifacts": {
+              "secondary-artifacts": {
+                "artifact2": {
+                  "base-directory": "output2",
+                  "files": [
+                    "**/*"
+                  ]
+                },
+                "Artifact_delivlibtestCodeCommitPipelineGenerateTwoArtifacts54497DAA": {
+                  "base-directory": "output1",
+                  "files": [
+                    "**/*"
+                  ]
+                }
+              }
+            }
+          }
+        Type: CODEPIPELINE
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/GenerateTwoArtifacts/Resource/Resource
+  CodeCommitPipelineGenerateTwoArtifactsAlarm4299580B:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Threshold: 1
+      Dimensions:
+        - Name: ProjectName
+          Value:
+            Ref: CodeCommitPipelineGenerateTwoArtifactsA9DAD33B
+      MetricName: FailedBuilds
+      Namespace: AWS/CodeBuild
+      Period: 300
+      Statistic: Sum
+      TreatMissingData: ignore
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/GenerateTwoArtifacts/Alarm/Resource
   CodeCommitPipelineCanaryHelloCanaryShellableRole65D634EB:
     Type: AWS::IAM::Role
     Properties:
@@ -2166,6 +2373,13 @@ Resources:
           - Name: FOR_REAL
             Type: PLAINTEXT
             Value: "true"
+          - Name: SECONDARY_SOURCE_NAMES
+            Type: PLAINTEXT
+            Value: Artifact_delivlibtestCodeCommitPipelineGenerateTwoArtifacts54497DAA
+              artifact2
+          - Name: SIGN_ADDITIONAL_ARTIFACTS
+            Type: PLAINTEXT
+            Value: "true"
         Image: aws/codebuild/nodejs:10.1.0
         PrivilegedMode: false
         Type: LINUX_CONTAINER
@@ -2692,16 +2906,17 @@ Resources:
               },
               "build": {
                 "commands": [
-                  "npm i && npm run bump",
-                  "aws secretsmanager get-secret-value --secret-id \"arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/github-ssh-lwzfjW\" --output=text --query=SecretString > ~/.ssh/id_rsa",
-                  "chmod 0600 ~/.ssh/id_rsa",
-                  "BRANCH=bump/$(git describe)",
-                  "git branch -D $BRANCH || true",
-                  "git checkout -b $BRANCH",
-                  "git checkout master",
-                  "git merge $BRANCH",
-                  "git remote add origin_ssh git@github.com:awslabs/aws-delivlib-sample.git",
-                  "git push --follow-tags origin_ssh master"
+                  "git describe --exact-match HEAD && { echo \"No new commits.\"; export SKIP=true; } || { echo \"Changes to release.\"; export SKIP=false; }",
+                  "$SKIP || { npm i && npm run bump; }",
+                  "$SKIP || aws secretsmanager get-secret-value --secret-id \"arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/github-ssh-lwzfjW\" --output=text --query=SecretString > ~/.ssh/id_rsa",
+                  "$SKIP || chmod 0600 ~/.ssh/id_rsa",
+                  "$SKIP || { BRANCH=bump/$(git describe) ; }",
+                  "$SKIP || { git branch -D $BRANCH || true ; }",
+                  "$SKIP || { git checkout -b $BRANCH ; }",
+                  "$SKIP || { git checkout master ; }",
+                  "$SKIP || { git merge $BRANCH ; }",
+                  "$SKIP || { git remote add origin_ssh git@github.com:awslabs/aws-delivlib-sample.git ; }",
+                  "$SKIP || { git push --follow-tags origin_ssh master ; }"
                 ]
               }
             }
@@ -3605,6 +3820,14 @@ Parameters:
     Type: String
     Description: S3 key for asset version
       "delivlib-test/CodeCommitPipeline/AssumeRole/ScriptDirectory"
+  CodeCommitPipelineGenerateTwoArtifactsScriptDirectoryS3BucketE058B7EF:
+    Type: String
+    Description: S3 bucket for asset
+      "delivlib-test/CodeCommitPipeline/GenerateTwoArtifacts/ScriptDirectory"
+  CodeCommitPipelineGenerateTwoArtifactsScriptDirectoryS3VersionKeyD775EF3D:
+    Type: String
+    Description: S3 key for asset version
+      "delivlib-test/CodeCommitPipeline/GenerateTwoArtifacts/ScriptDirectory"
   CodeCommitPipelineCanaryHelloCanaryShellableScriptDirectoryS3BucketFE4212CD:
     Type: String
     Description: S3 bucket for asset

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -167,7 +167,7 @@ test('can add arbitrary shellables with different artifacts', () => {
             ActionTypeId: { Category: "Build", Owner: "AWS", Provider: "CodeBuild", },
             InputArtifacts: [ { Name: "Artifact_PipelineBuildProjectBuildC2DBA0FC" } ],
             Name: "ActionSecondStep",
-            OutputArtifacts: [ { Name: "Artifact_PipelineSecondStepActionSecondStep47D84CAC" } ],
+            OutputArtifacts: [ { Name: "Artifact_PipelineSecondStepD5683DEB" } ],
             RunOrder: 1
           }
         ],
@@ -177,7 +177,7 @@ test('can add arbitrary shellables with different artifacts', () => {
         Actions: [
           {
             ActionTypeId: { Category: "Build", Owner: "AWS", Provider: "CodeBuild", },
-            InputArtifacts: [ { Name: "Artifact_PipelineSecondStepActionSecondStep47D84CAC" } ],
+            InputArtifacts: [ { Name: "Artifact_PipelineSecondStepD5683DEB" } ],
             Name: "PubPublish",
             OutputArtifacts: [ { Name: "Artifact_PubProjectPubPublishFC7A3C85" } ],
             RunOrder: 1

--- a/test/test-stack.ts
+++ b/test/test-stack.ts
@@ -82,8 +82,8 @@ export class TestStack extends cdk.Stack {
           'echo \'{"name": "output1", "version": "1.2.3", "commit": "abcdef"}\' > output1/build.json',
           'echo \'{"name": "output2", "version": "1.2.3", "commit": "abcdef"}\' > output2/build.json',
         ],
-        artifactDirectories: {
-          PRIMARY: 'output1',
+        artifactDirectory: 'output1',
+        additionalArtifactDirectories: {
           artifact2: 'output2'
         }
       })


### PR DESCRIPTION
Add multiple output artifact support for Shellable (including an initial
attempt at a BuildSpec helper as requested in awslabs/aws-cdk#2039).

Add multiple input artifact support for the GitHub publisher. The
tag and release notes will be taken from the primary artifact, the other
artifacts will be attached to the same release.

This is in preparation of publishing downloadable reference docs to
GitHub.