### PR TITLE
feat: support npm disttags

### DIFF
--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -83,6 +83,13 @@ export interface PublishToNpmProjectProps {
    * @default true
    */
   dryRun?: boolean;
+
+  /**
+   * npm dist-tag to use when publishing artifacts.
+   *
+   * @default - npm default behavior ("latest" unless dist tag is specified in package.json)
+   */
+  distTag?: string;
 }
 
 /**
@@ -103,7 +110,8 @@ export class PublishToNpmProject extends cdk.Construct implements IPublisher {
       entrypoint: 'publish.sh',
       environment: {
         FOR_REAL: forReal,
-        NPM_TOKEN_SECRET: props.npmTokenSecret.secretArn
+        NPM_TOKEN_SECRET: props.npmTokenSecret.secretArn,
+        DISTTAG: props.distTag || ''
       },
     });
 

--- a/lib/publishing/npm/publish-npm.sh
+++ b/lib/publishing/npm/publish-npm.sh
@@ -51,7 +51,7 @@ for TGZ in $(find ${PWD}/js -iname '*.tgz'); do
     # returns an empty string if the package exists, but version doesn't
     npm_view=$(npm view ${mod}@${ver} 2> /dev/null || true)
     if [ -z "${npm_view}" ]; then
-        $dry_npm publish $TGZ --access=public "${DISTTAG}" --loglevel=silly
+        $dry_npm publish $TGZ --access=public ${DISTTAG} --loglevel=silly
     else
         echo "⚠️ Package ${mod}@${ver} already published. Skipping."
     fi

--- a/lib/publishing/npm/publish-npm.sh
+++ b/lib/publishing/npm/publish-npm.sh
@@ -22,6 +22,11 @@ fi
 # NPM #
 #######
 
+DISTTAG=${DISTTAG:-""}
+if [ -n "${DISTTAG}" ]; then
+    DISTTAG="--tag=${DISTTAG}"
+fi
+
 echo "📦 Publishing to NPM"
 
 TOKENS=$(npm token list 2>&1 || echo '')
@@ -40,13 +45,13 @@ for TGZ in $(find ${PWD}/js -iname '*.tgz'); do
     ver="$(node -e "console.log(${packageInfo}.version);")"
 
     echo "-------------------------------------------------------------------------------------------------"
-    echo "Publishing to npm: ${mod}@${ver} from $TGZ"
+    echo "Publishing to npm: ${mod}@${ver} from $TGZ ${DISTTAG}"
 
     # check that the package is not already published using "npm view"
     # returns an empty string if the package exists, but version doesn't
     npm_view=$(npm view ${mod}@${ver} 2> /dev/null || true)
     if [ -z "${npm_view}" ]; then
-        $dry_npm publish $TGZ --access=public --loglevel silly
+        $dry_npm publish $TGZ --access=public "${DISTTAG}" --loglevel=silly
     else
         echo "⚠️ Package ${mod}@${ver} already published. Skipping."
     fi

--- a/lib/publishing/npm/publish-npm.sh
+++ b/lib/publishing/npm/publish-npm.sh
@@ -45,7 +45,7 @@ for TGZ in $(find ${PWD}/js -iname '*.tgz'); do
     ver="$(node -e "console.log(${packageInfo}.version);")"
 
     echo "-------------------------------------------------------------------------------------------------"
-    echo "Publishing to npm: ${mod}@${ver} from $TGZ ${DISTTAG}"
+    echo "Publishing to npm: ${mod}@${ver} ${DISTTAG} from $TGZ"
 
     # check that the package is not already published using "npm view"
     # returns an empty string if the package exists, but version doesn't

--- a/test/test-stack.ts
+++ b/test/test-stack.ts
@@ -88,8 +88,7 @@ export class TestStack extends cdk.Stack {
     //
 
     pipeline.publishToNpm({
-      npmTokenSecret: { secretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/npm-OynG62' },
-      // distTag: 'next'
+      npmTokenSecret: { secretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/npm-OynG62' }
     });
 
     // this creates a self-signed certificate

--- a/test/test-stack.ts
+++ b/test/test-stack.ts
@@ -88,7 +88,8 @@ export class TestStack extends cdk.Stack {
     //
 
     pipeline.publishToNpm({
-      npmTokenSecret: { secretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/npm-OynG62' }
+      npmTokenSecret: { secretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/npm-OynG62' },
+      // distTag: 'next'
     });
 
     // this creates a self-signed certificate


### PR DESCRIPTION
When publishing to npm, you can now specify `distTag: 'TAG'`
and we will publish with `--tag=TAG`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
