### PR TITLE
chore(release): v3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="3.7.1"></a>
+# [3.7.1](https://github.com/awslabs/aws-delivlib/compare/v3.7.0...v3.7.1) (2019-04-11)
+
+
+### Bug Fixes
+
+* **nuget-sign:** Use  osslsigncode for now, so SHA256 signatures can be used ([#92](https://github.com/awslabs/aws-delivlib/pull/92)) ([e2855af](https://github.com/awslabs/aws-delivlib/commit/e2855af))
+
+
+
 <a name="3.7.0"></a>
 # [3.7.0](https://github.com/awslabs/aws-delivlib/compare/v3.6.3...v3.7.0) (2019-04-10)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-delivlib",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-delivlib",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "homepage": "https://github.com/awslabs/aws-delivlib",
   "description": "A fabulous library for defining continuous pipelines for building, testing and releasing code libraries.",
   "main": "lib/index.js",

--- a/test/expected.json
+++ b/test/expected.json
@@ -1564,6 +1564,9 @@ Resources:
           - Name: NPM_TOKEN_SECRET
             Type: PLAINTEXT
             Value: arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/npm-OynG62
+          - Name: DISTTAG
+            Type: PLAINTEXT
+            Value: ""
         Image: aws/codebuild/nodejs:10.1.0
         PrivilegedMode: false
         Type: LINUX_CONTAINER


### PR DESCRIPTION
### Bug Fixes
	
* **nuget-sign:** Use  osslsigncode for now ([#92](https://github.com/awslabs/aws-delivlib/pull/92)) ([e2855af](https://github.com/awslabs/aws-delivlib/commit/e2855af))