### PR TITLE
feat: use mono's signcode to sign .NET assemblies

### DIFF
--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -181,7 +181,7 @@ export class PublishToNuGetProject extends cdk.Construct implements IPublisher {
     }
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_DOTNET_CORE_2_1),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.fromDockerHub('jsii/superchain')),
       scriptDirectory: path.join(__dirname, 'publishing', 'nuget'),
       entrypoint: 'publish.sh',
       environment,

--- a/lib/publishing/nuget/publish.sh
+++ b/lib/publishing/nuget/publish.sh
@@ -21,13 +21,17 @@ if [ -n "${CODE_SIGNING_SECRET_ID:-}" ]; then
 
     # Prepare the PEM encoded certificate for sign.sh to use
     echo "Reading certificate from SSM parameter: ${CODE_SIGNING_PARAMETER_NAME}"
-    signcode_spc="${cert}/certificate.pem"
-    aws ssm get-parameter --name "${CODE_SIGNING_PARAMETER_NAME}" | jq -r '.Parameter.Value' > "${signcode_spc}"
+    signcode_spc="${cert}/certificate.spc"
+    aws ssm get-parameter --name "${CODE_SIGNING_PARAMETER_NAME}" | jq -r '.Parameter.Value' > "${signcode_spc}.pem"
+    openssl crl2pkcs7 -nocrl -certfile "${signcode_spc}.pem" -outform DER -out "${signcode_spc}"
+    echo "Successfully converted certificate from PEM to DER (.spc)"
 
     # Prepare the PEM encoded private key for sign.sh to use
     echo "Reading signing key from secret ID: ${CODE_SIGNING_SECRET_ID}"
-    signcode_pvk="${cert}/certificate.key"
-    aws secretsmanager get-secret-value --secret-id "${CODE_SIGNING_SECRET_ID}" | jq -r '.SecretString' > "${signcode_pvk}"
+    signcode_pvk="${cert}/certificate.pvk"
+    aws secretsmanager get-secret-value --secret-id "${CODE_SIGNING_SECRET_ID}" | jq -r '.SecretString' > "${signcode_pvk}.pem"
+    openssl rsa -in "${signcode_pvk}.pem" -outform PVK -pvk-none -out "${signcode_pvk}"
+    echo "Successfully converted signing key from PEM to PVK"
 
     # Set the timestamp server
     signcode_tss="${CODE_SIGNING_TIMESTAMP_SERVER:-http://timestamp.digicert.com}"

--- a/lib/publishing/nuget/publish.sh
+++ b/lib/publishing/nuget/publish.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 set -eu # we don't want "pipefail" to implement idempotency
 
-echo "Installing jq..."
-apt update
-apt install -y jq
+echo "Installing required CLI tools: jq, openssl..."
+yum install -y jq openssl
 
 if [ -n "${CODE_SIGNING_SECRET_ID:-}" ]; then
     declare -a CLEANUP=()

--- a/test/expected.json
+++ b/test/expected.json
@@ -1941,7 +1941,7 @@ Resources:
             Type: PLAINTEXT
             Value:
               Ref: X509CodeSigningKey8DE65BF8
-        Image: aws/codebuild/dot-net:core-2.1
+        Image: jsii/superchain
         PrivilegedMode: false
         Type: LINUX_CONTAINER
       ServiceRole:


### PR DESCRIPTION
Now that Mono 6 is out we switched to the `jsii/superchain` image, which
uses this release, we are able to use `signcode` to issue `sha256`
signatures, instead of using un-maintained `osslsigncode`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
