### PR TITLE
feat: auto-build (with public logs)

### DIFF
--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -26,6 +26,10 @@ export interface AutoBuildProps extends AutoBuildOptions {
    */
   readonly environment: BuildEnvironmentProps;
 
+  /**
+   * Build spec.
+   */
+  readonly buildSpec?: any;
 }
 
 export class AutoBuild extends Construct {
@@ -36,6 +40,7 @@ export class AutoBuild extends Construct {
       source: props.repo.createBuildSource(this, true),
       environment: createBuildEnvironment(props.environment),
       badge: true,
+      buildSpec: props.buildSpec
     });
 
     // not support in this version of the cdk

--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -1,0 +1,63 @@
+import codebuild = require('@aws-cdk/aws-codebuild');
+import serverless = require('@aws-cdk/aws-serverless');
+import { Construct, Resource } from '@aws-cdk/cdk';
+import { BuildEnvironmentProps, createBuildEnvironment } from './build-env';
+import { IRepo } from './repo';
+
+export interface AutoBuildOptions {
+  /**
+   * Make build logs public and publishes a link to GitHub PR discussion.
+   *
+   * @see https://github.com/jlhood/github-codebuild-logs
+   *
+   * @default false
+   */
+  readonly publicLogs?: boolean;
+}
+
+export interface AutoBuildProps extends AutoBuildOptions {
+  /**
+   * The repository to monitor.
+   */
+  readonly repo: IRepo;
+
+  /**
+   * Build environment.
+   */
+  readonly environment: BuildEnvironmentProps;
+
+}
+
+export class AutoBuild extends Construct {
+  constructor(scope: Construct, id: string, props: AutoBuildProps) {
+    super(scope, id);
+
+    const project = new codebuild.Project(this, 'Project', {
+      source: props.repo.createBuildSource(this, true),
+      environment: createBuildEnvironment(props.environment),
+      badge: true,
+    });
+
+    // not support in this version of the cdk
+    const cfnProject = project.node.tryFindChild('Resource') as Resource;
+    cfnProject.addPropertyOverride('Triggers', {
+      Webhook: true,
+      FilterGroups: [
+        [ { Type: 'EVENT', Pattern: 'PUSH,PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED' } ]
+      ]
+    });
+
+    const publicLogs = props.publicLogs !== undefined ? props.publicLogs : false;
+    if (publicLogs) {
+      new serverless.CfnApplication(this, 'GitHubCodeBuildLogsSAR', {
+        location: {
+          applicationId: 'arn:aws:serverlessrepo:us-east-1:277187709615:applications/github-codebuild-logs',
+          semanticVersion: '1.0.3'
+        },
+        parameters: {
+          CodeBuildProjectName: project.projectName
+        }
+      });
+    }
+  }
+}

--- a/lib/bump/bump.ts
+++ b/lib/bump/bump.ts
@@ -131,7 +131,7 @@ export class AutoBump extends cdk.Construct {
     pushCommands.push(`git push --follow-tags origin_ssh ${targetBranch }`);
 
     const project = new cbuild.Project(this, 'Bump', {
-      source: props.repo.createBuildSource(this),
+      source: props.repo.createBuildSource(this, false),
       environment: createBuildEnvironment(props),
       buildSpec: {
         version: '0.2',

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -142,6 +142,7 @@ export class Pipeline extends cdk.Construct {
   private readonly repo: IRepo;
   private readonly dryRun: boolean;
   private readonly buildEnvironment: BuildEnvironment;
+  private readonly buildSpec?: any;
 
   constructor(parent: cdk.Construct, name: string, props: PipelineProps) {
     super(parent, name);
@@ -159,10 +160,11 @@ export class Pipeline extends cdk.Construct {
     const source = props.repo.createSourceStage(this.pipeline, this.branch);
 
     this.buildEnvironment = createBuildEnvironment(props);
+    this.buildSpec = props.buildSpec;
 
     const buildProject = new cbuild.PipelineProject(this, 'BuildProject', {
       environment: this.buildEnvironment,
-      buildSpec: props.buildSpec,
+      buildSpec: this.buildSpec,
     });
 
     this.buildRole = buildProject.role;
@@ -321,6 +323,7 @@ export class Pipeline extends cdk.Construct {
     new AutoBuild(this, 'AutoBuild', {
       environment: this.buildEnvironment,
       repo: this.repo,
+      buildSpec: this.buildSpec,
       ...options
     });
   }

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -1,11 +1,13 @@
 import cloudwatch = require('@aws-cdk/aws-cloudwatch');
 import cbuild = require('@aws-cdk/aws-codebuild');
+import { BuildEnvironment } from '@aws-cdk/aws-codebuild';
 import cpipeline = require('@aws-cdk/aws-codepipeline');
 import cpipelineapi = require('@aws-cdk/aws-codepipeline-api');
 import iam = require('@aws-cdk/aws-iam');
 import s3 = require('@aws-cdk/aws-s3');
 import sns = require('@aws-cdk/aws-sns');
 import cdk = require('@aws-cdk/cdk');
+import { AutoBuild, AutoBuildOptions } from './auto-build';
 import { createBuildEnvironment } from './build-env';
 import { AutoBump, AutoBumpOptions } from './bump';
 import { Canary, CanaryProps } from './canary';
@@ -109,6 +111,18 @@ export interface PipelineProps {
    * @default false
    */
   dryRun?: boolean;
+
+  /**
+   * Automatically build commits that are pushed to this repository, including PR builds on github.
+   */
+  autoBuild?: boolean;
+
+  /**
+   * Options for auto-build
+   *
+   * @default - defaults
+   */
+  autoBuildOptions?: AutoBuildOptions;
 }
 
 /**
@@ -127,6 +141,7 @@ export class Pipeline extends cdk.Construct {
   private readonly concurrency?: number;
   private readonly repo: IRepo;
   private readonly dryRun: boolean;
+  private readonly buildEnvironment: BuildEnvironment;
 
   constructor(parent: cdk.Construct, name: string, props: PipelineProps) {
     super(parent, name);
@@ -143,8 +158,10 @@ export class Pipeline extends cdk.Construct {
     this.branch = props.branch || 'master';
     const source = props.repo.createSourceStage(this.pipeline, this.branch);
 
+    this.buildEnvironment = createBuildEnvironment(props);
+
     const buildProject = new cbuild.PipelineProject(this, 'BuildProject', {
-      environment: createBuildEnvironment(props),
+      environment: this.buildEnvironment,
       buildSpec: props.buildSpec,
     });
 
@@ -165,6 +182,10 @@ export class Pipeline extends cdk.Construct {
 
     // emit an SNS notification every time build fails.
     this.addBuildFailureNotification(buildProject, `${props.title} build failed`);
+
+    if (props.autoBuild) {
+      this.autoBuild(props.autoBuildOptions);
+    }
   }
 
   /**
@@ -288,6 +309,17 @@ export class Pipeline extends cdk.Construct {
     }
 
     return new AutoBump(this, 'AutoBump', {
+      repo: this.repo,
+      ...options
+    });
+  }
+
+  /**
+   * Enables automatic builds of
+   */
+  public autoBuild(options: AutoBuildOptions = { }) {
+    new AutoBuild(this, 'AutoBuild', {
+      environment: this.buildEnvironment,
       repo: this.repo,
       ...options
     });

--- a/lib/repo.ts
+++ b/lib/repo.ts
@@ -8,7 +8,7 @@ import { ExternalSecret } from './permissions';
 export interface IRepo {
   repositoryUrlHttp: string;
   repositoryUrlSsh: string;
-  createBuildSource(parent: cdk.Construct): cbuild.BuildSource;
+  createBuildSource(parent: cdk.Construct, webhook: boolean): cbuild.BuildSource;
   createSourceStage(pipeline: cpipeline.Pipeline, branch: string): cpipelineapi.SourceAction;
   describe(): any;
 }
@@ -98,13 +98,15 @@ export class GitHubRepo implements IRepo {
     });
   }
 
-  public createBuildSource(parent: cdk.Construct) {
+  public createBuildSource(parent: cdk.Construct, webhook: boolean) {
     const oauth = new cdk.SecretParameter(parent, 'GitHubToken', { ssmParameter: this.tokenParameterName });
 
     return new cbuild.GitHubSource({
       owner: this.owner,
       repo: this.repo,
       oauthToken: oauth.value,
+      webhook,
+      reportBuildStatus: webhook
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -356,6 +356,14 @@
         "@aws-cdk/cdk": "^0.24.1"
       }
     },
+    "@aws-cdk/aws-serverless": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-serverless/-/aws-serverless-0.24.1.tgz",
+      "integrity": "sha512-X7UygOXsNhrfDUFPPkzQfEJjTmUgMyAQmmu8VnEtj4nnpncK//QM0X7V8lmB1ex85TOfNWaK4UXC/QjNa+FwOw==",
+      "requires": {
+        "@aws-cdk/cdk": "^0.24.1"
+      }
+    },
     "@aws-cdk/aws-sns": {
       "version": "0.24.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-0.24.1.tgz",
@@ -3424,7 +3432,7 @@
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
@@ -4089,7 +4097,7 @@
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
@@ -4124,7 +4132,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -4143,7 +4151,7 @@
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
@@ -4254,7 +4262,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -4827,7 +4835,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -6037,7 +6045,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -6683,7 +6691,7 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
@@ -7028,7 +7036,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -7277,7 +7285,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -8575,7 +8583,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -8943,7 +8951,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -9445,7 +9453,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@aws-cdk/aws-cloudformation": "^0.24.1",
     "@aws-cdk/aws-codebuild": "^0.24.1",
     "@aws-cdk/aws-codecommit": "^0.24.1",
+    "@aws-cdk/aws-serverless": "^0.24.1",
     "@aws-cdk/aws-codepipeline": "^0.24.1",
     "@aws-cdk/aws-ecs": "^0.24.1",
     "@aws-cdk/aws-lambda": "^0.24.1",

--- a/pipeline/delivlib.ts
+++ b/pipeline/delivlib.ts
@@ -46,7 +46,9 @@ export class DelivLibPipelineStack extends cdk.Stack {
           'files': [ '**/*' ],
           'base-directory': 'dist'
         }
-      }
+      },
+      autoBuild: true,
+      autoBuildOptions: { publicLogs: true }
     });
 
     pipeline.publishToNpm({

--- a/test/expected.json
+++ b/test/expected.json
@@ -1,3 +1,4 @@
+Transform: AWS::Serverless-2016-10-31
 Resources:
   CodeCommitPipelineBuildPipelineArtifactsBucketED2813B3:
     Type: AWS::S3::Bucket
@@ -2851,8 +2852,10 @@ Resources:
             }
           }
         Location: https://github.com/awslabs/aws-delivlib-sample.git
-        ReportBuildStatus: true
+        ReportBuildStatus: false
         Type: GITHUB
+      Triggers:
+        Webhook: false
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBump/Bump/Resource
   CodeCommitPipelineAutoBumpEventsRole63A4AC28:
@@ -2919,6 +2922,89 @@ Resources:
       TreatMissingData: ignore
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBump/BumpFailedAlarm/Resource
+  CodeCommitPipelineAutoBuildProjectRole733AD222:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: "2012-10-17"
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBuild/Project/Role/Resource
+  CodeCommitPipelineAutoBuildProjectRoleDefaultPolicyFF5563AC:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - :logs:us-east-1:712950704752:log-group:/aws/codebuild/
+                    - Ref: CodeCommitPipelineAutoBuildProject5D212EE9
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - :logs:us-east-1:712950704752:log-group:/aws/codebuild/
+                    - Ref: CodeCommitPipelineAutoBuildProject5D212EE9
+                    - :*
+        Version: "2012-10-17"
+      PolicyName: CodeCommitPipelineAutoBuildProjectRoleDefaultPolicyFF5563AC
+      Roles:
+        - Ref: CodeCommitPipelineAutoBuildProjectRole733AD222
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBuild/Project/Role/DefaultPolicy/Resource
+  CodeCommitPipelineAutoBuildProject5D212EE9:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: jsii/superchain:latest
+        PrivilegedMode: false
+        Type: LINUX_CONTAINER
+      ServiceRole:
+        Fn::GetAtt:
+          - CodeCommitPipelineAutoBuildProjectRole733AD222
+          - Arn
+      Source:
+        Auth:
+          Resource:
+            Ref: CodeCommitPipelineAutoBuildGitHubTokenParameter7CA2BBB3
+          Type: OAUTH
+        Location: https://github.com/awslabs/aws-delivlib-sample.git
+        ReportBuildStatus: true
+        Type: GITHUB
+      BadgeEnabled: true
+      Triggers:
+        Webhook: true
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: PUSH,PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBuild/Project/Resource
+  CodeCommitPipelineAutoBuildGitHubCodeBuildLogsSAR75EABC5D:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:277187709615:applications/github-codebuild-logs
+        SemanticVersion: 1.0.3
+      Parameters:
+        CodeBuildProjectName:
+          Ref: CodeCommitPipelineAutoBuildProject5D212EE9
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBuild/GitHubCodeBuildLogsSAR
   CodeCommitPipelineChangeControllerCalendar94B1DEA8:
     Type: AWS::S3::Bucket
     Properties:
@@ -3714,6 +3800,10 @@ Parameters:
     Description: S3 key for asset version
       "delivlib-test/CodeCommitPipeline/PyPI/Default/ScriptDirectory"
   CodeCommitPipelineAutoBumpGitHubTokenParameter20350017:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: github-token
+    NoEcho: true
+  CodeCommitPipelineAutoBuildGitHubTokenParameter7CA2BBB3:
     Type: AWS::SSM::Parameter::Value<String>
     Default: github-token
     NoEcho: true

--- a/test/test-stack.ts
+++ b/test/test-stack.ts
@@ -167,6 +167,13 @@ export class TestStack extends cdk.Stack {
     });
 
     //
+    // AUTO-BUILD
+
+    pipeline.autoBuild({
+      publicLogs: true
+    });
+
+    //
     // CHANGE CONTROL
     //
 


### PR DESCRIPTION
If the `autoBuild` flag is set, a CodeBuild project
will be created and configured to automatically build
any commits to the repo, including GitHub pull requests.

If the `publicLogs` flag is also set, build logs will be published
to S3 and also a comment will automatically be posted on the GitHub
PR with a link.

Fixes #42

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
