### PR TITLE
feat: configure buildspec for AutoBuild project

### DIFF
--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -13,6 +13,15 @@ export interface AutoBuildOptions {
    * @default false
    */
   readonly publicLogs?: boolean;
+
+  /* tslint:disable:max-line-length */
+  /**
+   * Build spec file to use for AutoBuild
+   *
+   * @default @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-source.html#cfn-codebuild-project-source-buildspec
+   */
+  readonly buildSpec?: any;
+  /* tslint:enable:max-line-length */
 }
 
 export interface AutoBuildProps extends AutoBuildOptions {
@@ -25,11 +34,6 @@ export interface AutoBuildProps extends AutoBuildOptions {
    * Build environment.
    */
   readonly environment: BuildEnvironmentProps;
-
-  /**
-   * Build spec.
-   */
-  readonly buildSpec?: any;
 }
 
 export class AutoBuild extends Construct {

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -319,7 +319,7 @@ export class Pipeline extends cdk.Construct {
 
   /**
    * Enables automatic builds of pull requests in the Github repository and posts the
-   * results of the build back as a comment with a public link to the build logs.
+   * results back as a comment with a public link to the build logs.
    */
   public autoBuild(options: AutoBuildOptions = { }) {
     new AutoBuild(this, 'AutoBuild', {

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -120,7 +120,8 @@ export interface PipelineProps {
   /**
    * Options for auto-build
    *
-   * @default - defaults
+   * @default - 'autoBuildOptions.publicLogs' will be set to its default. 'autoBuildOptions.buildspec' will be configured to match with the
+   * 'buildSpec' property.
    */
   autoBuildOptions?: AutoBuildOptions;
 }
@@ -317,13 +318,14 @@ export class Pipeline extends cdk.Construct {
   }
 
   /**
-   * Enables automatic builds of
+   * Enables automatic builds of pull requests in the Github repository and posts the
+   * results of the build back as a comment with a public link to the build logs.
    */
   public autoBuild(options: AutoBuildOptions = { }) {
     new AutoBuild(this, 'AutoBuild', {
       environment: this.buildEnvironment,
       repo: this.repo,
-      buildSpec: this.buildSpec,
+      buildSpec: options.buildSpec || this.buildSpec,
       ...options
     });
   }

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -259,6 +259,35 @@ test('autoBuild() can be configured to publish logs publically', () => {
   }));
 });
 
+test('autoBuild() can be configured with a different buildspec', () => {
+  // GIVEN
+  const stack = new cdk.Stack();
+
+  // WHEN
+  new delivlib.Pipeline(stack, 'Pipeline', {
+    repo: createTestRepo(stack),
+    pipelineName: 'HelloPipeline',
+    autoBuild: true,
+    autoBuildOptions: {
+      buildSpec: 'different-buildspec.yaml',
+    },
+  });
+
+  // THEN
+  cdk_expect(stack).to(haveResource('AWS::CodeBuild::Project', {
+    Source: {
+      BuildSpec: "different-buildspec.yaml",
+      Location: {
+        "Fn::GetAtt": [
+          "Repo02AC86CF",
+          "CloneUrlHttp"
+        ]
+      },
+      Type: "CODECOMMIT",
+    }
+  }));
+});
+
 class Pub extends cdk.Construct implements IPublisher {
   public readonly project: codebuild.IProject;
 


### PR DESCRIPTION
Allow a different buildspec to be specified for the AutoBuild project.
This enables PR builds to use a different buildspec file from the
CodeBuild project in the pipeline.

MOTIVATION
The aws-cdk package spends a significant amount of time (~20 minutes) in
the post-build step, where the build artifacts are packed. This, however, is
unnecessary for PR builds where the intention is to check if the build passes.
Specifying a separate buildspec.yml that has no post-build step will
speed up PR builds.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
