### PR TITLE
fix: fix broken maven publishing

### DIFF
--- a/lib/build-spec.ts
+++ b/lib/build-spec.ts
@@ -47,6 +47,7 @@ export class BuildSpec {
     return new BuildSpec({
       version: "0.2",
       phases: noUndefined({
+        install: props.install !== undefined ? { commands: props.install } : undefined,
         pre_build: props.preBuild !== undefined ? { commands: props.preBuild } : undefined,
         build: props.build !== undefined ? { commands: props.build } : undefined,
       }),
@@ -156,6 +157,7 @@ export class BuildSpec {
 }
 
 export interface SimpleBuildSpecProps {
+  install?: string[];
   preBuild?: string[];
   build?: string[];
 

--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -56,9 +56,13 @@ export class PublishToMavenProject extends cdk.Construct implements IPublisher {
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_10_1_0),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.fromDockerRegistry('node:10-jessie')),
       scriptDirectory: path.join(__dirname, 'publishing', 'maven'),
       entrypoint: 'publish.sh',
+      install: [
+        'apt-get update > /dev/null && apt-get install -y python python-pip',
+        'pip install awscli'
+      ],
       environment: {
         STAGING_PROFILE_ID: props.stagingProfileId,
         SIGNING_KEY_ARN: props.signingKey.credential.secretArn,

--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -106,6 +106,10 @@ export interface ShellableOptions {
  */
 export interface ShellableProps extends ShellableOptions {
   /**
+   * Install Steps
+   */
+  install?: string[];
+  /**
    * Directory with the scripts.
    *
    * The whole directory will be uploaded.
@@ -208,6 +212,7 @@ export class Shellable extends cdk.Construct {
     }
 
     this.buildSpec = BuildSpec.simple({
+      install: props.install,
       preBuild: this.platform.prebuildCommands(props.assumeRole),
       build: this.platform.buildCommands(props.entrypoint)
     }).merge(props.buildSpec || BuildSpec.empty());


### PR DESCRIPTION
Fixes broken maven publishing task by updating the build environment to
use a newer version of maven.

Fixes #217

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
