### PR TITLE
fix(chime): make Chime notifier actually deploy

### DIFF
--- a/lib/chime-notifier/notifier-handler.ts
+++ b/lib/chime-notifier/notifier-handler.ts
@@ -30,12 +30,11 @@ export async function handler(event: any) {
   // Log the event so we can have a look in CloudWatch logs
   process.stdout.write(`${JSON.stringify(event)}\n`);
 
-  const webhookUrlsVar = process.env.WEBHOOK_URLS;
-  if (!webhookUrlsVar) { throw new Error("Expect environment variable 'WEBHOOK_URLS'"); }
-  const webhookUrls = webhookUrlsVar.split('|');
+  const webhookUrls: string[] = event.webhookUrls || [];
+  if (webhookUrls.length === 0) { throw new Error("Expected event field 'webhookUrls'"); }
 
-  const messageTemplate = process.env.MESSAGE;
-  if (!messageTemplate) { throw new Error("Expect environment variable 'MESSAGE'"); }
+  const messageTemplate = event.message;
+  if (!messageTemplate) { throw new Error("Expected event field 'message'"); }
 
   const details = event.detail || {};
   const pipelineName = details.pipeline;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,3 +11,4 @@ export * from './shellable';
 export * from './signing-key';
 export * from './code-signing';
 export * from './bump';
+export * from './chime-notifier';

--- a/pipeline/delivlib.ts
+++ b/pipeline/delivlib.ts
@@ -8,6 +8,7 @@
 //
 import codebuild = require('@aws-cdk/aws-codebuild');
 import cdk = require('@aws-cdk/core');
+import * as ssm from '@aws-cdk/aws-ssm';
 import delivlib = require('../lib');
 
 export class DelivLibPipelineStack extends cdk.Stack {
@@ -49,7 +50,11 @@ export class DelivLibPipelineStack extends cdk.Stack {
         }
       }),
       autoBuild: true,
-      autoBuildOptions: { publicLogs: true }
+      autoBuildOptions: { publicLogs: true },
+
+      // We can't put the list of webhook URLs directly in here since this repository is open source and
+      // the list of URLs would be enough to spam us. Import from an SSM parameter.
+      chimeFailureWebhooks: [ssm.StringParameter.fromStringParameterName(this, 'WebhookList', 'BuildWebhook').stringValue],
     });
 
     pipeline.publishToNpm({


### PR DESCRIPTION
- The source was too big for inline code and so it didn't actually
  deploy: strip out the source map.
- Move the configuration into the Lambda trigger's input (instead of
  environment variables) so we can use a SingletonFunction for all
  pipelines in the project.
- Add missing permissions to list the pipeline's actions.
- Fix the pattern

Add to Delivlib's own pipeline to properly test it.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
