### PR TITLE
fix: public build logs are broken

### DIFF
--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -1,6 +1,6 @@
 import codebuild = require('@aws-cdk/aws-codebuild');
 import serverless = require('@aws-cdk/aws-sam');
-import { Construct } from '@aws-cdk/core';
+import { Construct, Token } from '@aws-cdk/core';
 import { BuildEnvironmentProps, createBuildEnvironment } from './build-env';
 import { IRepo } from './repo';
 
@@ -27,6 +27,8 @@ export interface AutoBuildOptions {
 export interface AutoBuildProps extends AutoBuildOptions {
   /**
    * The repository to monitor.
+   *
+   * Must be a GitHub repository for `publicLogs` to have any effect.
    */
   readonly repo: IRepo;
 
@@ -67,10 +69,11 @@ export class AutoBuild extends Construct {
       new serverless.CfnApplication(this, 'GitHubCodeBuildLogsSAR', {
         location: {
           applicationId: 'arn:aws:serverlessrepo:us-east-1:277187709615:applications/github-codebuild-logs',
-          semanticVersion: '1.0.3'
+          semanticVersion: '1.3.0'
         },
         parameters: {
-          CodeBuildProjectName: project.projectName
+          CodeBuildProjectName: project.projectName,
+          ...props.repo.token ? { GitHubOAuthToken: Token.asString(props.repo.token)} : undefined,
         }
       });
     }

--- a/lib/repo.ts
+++ b/lib/repo.ts
@@ -4,11 +4,13 @@ import cpipeline = require('@aws-cdk/aws-codepipeline');
 import cpipeline_actions = require('@aws-cdk/aws-codepipeline-actions');
 import cdk = require('@aws-cdk/core');
 import { ExternalSecret } from './permissions';
+import { SecretValue } from '@aws-cdk/core';
 
 export interface IRepo {
   repositoryUrlHttp: string;
   repositoryUrlSsh: string;
   readonly allowsBadge: boolean;
+  readonly token: SecretValue | undefined;
   createBuildSource(parent: cdk.Construct, webhook: boolean, branch?: string): cbuild.ISource;
   createSourceStage(pipeline: cpipeline.Pipeline, branch: string): cpipeline.Artifact;
   describe(): any;
@@ -16,6 +18,7 @@ export interface IRepo {
 
 export class CodeCommitRepo implements IRepo {
   public readonly allowsBadge = false;
+  public readonly token: SecretValue | undefined = undefined;
 
   constructor(private readonly repository: ccommit.IRepository) {
 

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -3916,10 +3916,11 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:277187709615:applications/github-codebuild-logs
-        SemanticVersion: 1.0.3
+        SemanticVersion: 1.3.0
       Parameters:
         CodeBuildProjectName:
           Ref: CodeCommitPipelineAutoBuildProject5D212EE9
+        GitHubOAuthToken: "{{resolve:secretsmanager:github-token:SecretString:::}}"
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBuild/GitHubCodeBuildLogsSAR
   CodeCommitPipelineChangeControllerCalendar94B1DEA8:

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -207,7 +207,7 @@ test('autoBuild() can be used to add automatic builds to the pipeline', () => {
   cdk_expect(stack).notTo(haveResource('AWS::Serverless::Application', {
     Location: {
       ApplicationId: "arn:aws:serverlessrepo:us-east-1:277187709615:applications/github-codebuild-logs",
-      SemanticVersion: "1.0.3"
+      SemanticVersion: "1.3.0"
     }
   }));
 });

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -229,7 +229,7 @@ test('autoBuild() can be configured to publish logs publically', () => {
   cdk_expect(stack).to(haveResource('AWS::Serverless::Application', {
     Location: {
       ApplicationId: "arn:aws:serverlessrepo:us-east-1:277187709615:applications/github-codebuild-logs",
-      SemanticVersion: "1.0.3"
+      SemanticVersion: "1.3.0"
     }
   }));
 });


### PR DESCRIPTION
The public build logs Serverless App retrieves the GitHub Token from the
CodeBuild project it's monitoring. For some reason (maybe because we
switched to Secrets Manager secrets) that token can't be retrieved
anymore and the posting would fail.

Also, the specific fields that the serverless app was reading have
been loudly deprecated according to the CodeBuild docs:

https://docs.aws.amazon.com/codebuild/latest/APIReference/API_ProjectSource.html#CodeBuild-Type-ProjectSource-auth

Update to a newer version of the serverless app in which this
token is an explicit parameter.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
