### PR TITLE
feat(bump): create pull request for bumps

### DIFF
--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -58,7 +58,7 @@ export class AutoBuild extends Construct {
 
     const project = new codebuild.Project(this, 'Project', {
       projectName: props.projectName,
-      source: props.repo.createBuildSource(this, true, props.branch),
+      source: props.repo.createBuildSource(this, true, { branch: props.branch }),
       environment: createBuildEnvironment(props.environment),
       badge: props.repo.allowsBadge,
       buildSpec: props.buildSpec

--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -1,6 +1,6 @@
 import codebuild = require('@aws-cdk/aws-codebuild');
 import serverless = require('@aws-cdk/aws-sam');
-import { Construct, Token } from '@aws-cdk/core';
+import { Construct, Token, SecretValue } from '@aws-cdk/core';
 import { BuildEnvironmentProps, createBuildEnvironment } from './build-env';
 import { IRepo } from './repo';
 
@@ -65,6 +65,8 @@ export class AutoBuild extends Construct {
     });
 
     const publicLogs = props.publicLogs !== undefined ? props.publicLogs : false;
+    const githubToken = props.repo.tokenSecretArn ? SecretValue.secretsManager(props.repo.tokenSecretArn) : undefined;
+
     if (publicLogs) {
       new serverless.CfnApplication(this, 'GitHubCodeBuildLogsSAR', {
         location: {
@@ -73,7 +75,7 @@ export class AutoBuild extends Construct {
         },
         parameters: {
           CodeBuildProjectName: project.projectName,
-          ...props.repo.token ? { GitHubOAuthToken: Token.asString(props.repo.token)} : undefined,
+          ...githubToken ? { GitHubOAuthToken: Token.asString(githubToken)} : undefined,
         }
       });
     }

--- a/lib/bump/bump.ts
+++ b/lib/bump/bump.ts
@@ -77,7 +77,7 @@ export interface AutoBumpOptions {
    * The name of the branch to push the bump commit (e.g. "master")
    * This branch has to exist.
    *
-   * @default the commit will be pushed to the branch `bump/$VERSION`
+   * @default - the commit will be pushed to the branch `bump/$VERSION`
    */
   branch?: string;
 
@@ -188,6 +188,15 @@ export class AutoBump extends cdk.Construct {
 
     const pullRequestEnabled = props.pullRequest || props.pullRequestOptions;
     if (pullRequestEnabled) {
+
+      // we can't create a pull request if base=head
+      if (props.branch) {
+        const base = props.pullRequestOptions?.base ?? 'master';
+        if (props.branch === base) {
+          throw new Error(`cannot enable pull requests since the head branch ("${props.branch}") is the same as the base branch ("${base}")`);
+        }
+      }
+
       pushCommands.push(...createPullRequestCommands(props.repo, props.pullRequestOptions));
     }
 

--- a/lib/bump/bump.ts
+++ b/lib/bump/bump.ts
@@ -94,6 +94,13 @@ export interface AutoBumpOptions {
    * @default - default options
    */
   pullRequestOptions?: PullRequestOptions;
+
+  /**
+   * Git clone depth
+   *
+   * @default 0 clones the entire repository
+   */
+  cloneDepth?: number;
 }
 
 export interface AutoBumpProps extends AutoBumpOptions {
@@ -184,8 +191,11 @@ export class AutoBump extends cdk.Construct {
       pushCommands.push(...createPullRequestCommands(props.repo, props.pullRequestOptions));
     }
 
+    // by default, clone the entire repo (cloneDepth: 0)
+    const cloneDepth = props.cloneDepth === undefined ? 0 : props.cloneDepth;
+
     const project = new cbuild.Project(this, 'Bump', {
-      source: props.repo.createBuildSource(this, false),
+      source: props.repo.createBuildSource(this, false, { cloneDepth }),
       environment: createBuildEnvironment(props),
       buildSpec: cbuild.BuildSpec.fromObject({
         version: '0.2',

--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -358,6 +358,8 @@ export class PublishToGitHub extends cdk.Construct implements IPublisher {
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
     this.additionalInputArtifacts = props.additionalInputArtifacts;
 
+    const githubToken = cdk.SecretValue.secretsManager(props.githubRepo.tokenSecretArn);
+
     const shellable = new Shellable(this, 'Default', {
       platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_10_1_0),
       scriptDirectory: path.join(__dirname, 'publishing', 'github'),
@@ -366,7 +368,7 @@ export class PublishToGitHub extends cdk.Construct implements IPublisher {
         BUILD_MANIFEST: props.buildManifestFileName || './build.json',
         CHANGELOG: props.changelogFileName || './CHANGELOG.md',
         SIGNING_KEY_ARN: props.signingKey.credential.secretArn,
-        GITHUB_TOKEN: props.githubRepo.token.toString(),
+        GITHUB_TOKEN: githubToken.toString(),
         GITHUB_OWNER: props.githubRepo.owner,
         GITHUB_REPO: props.githubRepo.repo,
         FOR_REAL: forReal,

--- a/lib/repo.ts
+++ b/lib/repo.ts
@@ -10,9 +10,14 @@ export interface IRepo {
   repositoryUrlSsh: string;
   readonly allowsBadge: boolean;
   readonly tokenSecretArn?: string;
-  createBuildSource(parent: cdk.Construct, webhook: boolean, branch?: string): cbuild.ISource;
+  createBuildSource(parent: cdk.Construct, webhook: boolean, options?: BuildSourceOptions): cbuild.ISource;
   createSourceStage(pipeline: cpipeline.Pipeline, branch: string): cpipeline.Artifact;
   describe(): any;
+}
+
+export interface BuildSourceOptions {
+  branch?: string;
+  cloneDepth?: number;
 }
 
 export class CodeCommitRepo implements IRepo {
@@ -45,9 +50,10 @@ export class CodeCommitRepo implements IRepo {
     return this.repository.repositoryCloneUrlSsh;
   }
 
-  public createBuildSource(_: cdk.Construct, _webhook: boolean): cbuild.ISource {
+  public createBuildSource(_: cdk.Construct, _webhook: boolean, options: BuildSourceOptions = { }): cbuild.ISource {
     return cbuild.Source.codeCommit({
       repository: this.repository,
+      cloneDepth: options.cloneDepth,
     });
   }
 
@@ -106,17 +112,17 @@ export class GitHubRepo implements IRepo {
     return sourceOutput;
   }
 
-  public createBuildSource(_: cdk.Construct, webhook: boolean, branch?: string): cbuild.ISource {
+  public createBuildSource(_: cdk.Construct, webhook: boolean, options: BuildSourceOptions = { }): cbuild.ISource {
     return cbuild.Source.gitHub({
       owner: this.owner,
       repo: this.repo,
       webhook,
+      cloneDepth: options.cloneDepth,
       reportBuildStatus: webhook,
       webhookFilters: webhook
-          ? this.createWebhookFilters(branch)
+          ? this.createWebhookFilters(options.branch)
           : undefined,
     });
-
   }
 
   public describe() {

--- a/pipeline/delivlib.ts
+++ b/pipeline/delivlib.ts
@@ -17,7 +17,7 @@ export class DelivLibPipelineStack extends cdk.Stack {
 
     const github = new delivlib.WritableGitHubRepo({
       repository: 'awslabs/aws-delivlib',
-      token: cdk.SecretValue.secretsManager('github-token'),
+      tokenSecretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW',
       commitEmail: 'aws-cdk-dev+delivlib@amazon.com',
       commitUsername: 'aws-cdk-dev',
       sshKeySecret: { secretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/github-ssh-lwzfjW' }

--- a/test/bump.test.ts
+++ b/test/bump.test.ts
@@ -1,0 +1,279 @@
+// tslint:disable: max-line-length
+import { Stack } from "@aws-cdk/core";
+import { AutoBump, WritableGitHubRepo } from "../lib";
+import '@aws-cdk/assert/jest';
+
+const MOCK_REPO = new WritableGitHubRepo({
+  sshKeySecret: { secretArn: 'ssh-key-secret-arn' },
+  commitUsername: 'user',
+  commitEmail: 'email@email',
+  repository: 'owner/repo',
+  tokenSecretArn: 'token-secret-arn'
+});
+
+test('autoBump', () => {
+  // GIVEN
+  const stack = new Stack();
+
+  // WHEN
+  new AutoBump(stack, 'MyAutoBump', {
+    repo: MOCK_REPO
+  });
+
+  // THEN
+
+  // build project
+  expect(stack).toHaveResource('AWS::CodeBuild::Project', {
+    Triggers: {
+      Webhook: false
+    },
+    Source: {
+      Type: 'GITHUB',
+      GitCloneDepth: 0,
+      Location: "https://github.com/owner/repo.git",
+      ReportBuildStatus: false,
+      BuildSpec: JSON.stringify({
+        "version": "0.2",
+        "phases": {
+          "pre_build": {
+            "commands": [
+              "git config --global user.email \"email@email\"",
+              "git config --global user.name \"user\""
+            ]
+          },
+          "build": {
+            "commands": [
+              "git describe --exact-match HEAD && { echo \"No new commits.\"; export SKIP=true; } || { echo \"Changes to release.\"; export SKIP=false; }",
+              "$SKIP || { /bin/sh ./bump.sh; }",
+              "$SKIP || aws secretsmanager get-secret-value --secret-id \"ssh-key-secret-arn\" --output=text --query=SecretString > ~/.ssh/id_rsa",
+              "$SKIP || mkdir -p ~/.ssh",
+              "$SKIP || chmod 0600 ~/.ssh/id_rsa",
+              "$SKIP || chmod 0600 ~/.ssh/config",
+              "$SKIP || ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts",
+              "$SKIP || { export VERSION=$(git describe) ; }",
+              "$SKIP || { export BRANCH=bump/$VERSION ; }",
+              "$SKIP || { git branch -D $BRANCH || true ; }",
+              "$SKIP || { git checkout -b $BRANCH ; }",
+              "$SKIP || { git remote add origin_ssh git@github.com:owner/repo.git ; }",
+              "$SKIP || { git push --follow-tags origin_ssh $BRANCH ; }"
+            ]
+          }
+        }
+      }, undefined, 2)
+    }
+  });
+
+  // default schedule
+  expect(stack).toHaveResource('AWS::Events::Rule', {
+    ScheduleExpression: "cron(0 12 * * ? *)"
+  });
+});
+
+test('autoBump with custom cloneDepth', () => {
+  // GIVEN
+  const stack = new Stack();
+
+  // WHEN
+  new AutoBump(stack, 'MyAutoBump', {
+    repo: MOCK_REPO,
+    cloneDepth: 10
+  });
+
+  // THEN
+
+  // build project
+  expect(stack).toHaveResource('AWS::CodeBuild::Project', {
+    Triggers: {
+      Webhook: false
+    },
+    Source: {
+      Type: 'GITHUB',
+      GitCloneDepth: 10,
+      Location: "https://github.com/owner/repo.git",
+      ReportBuildStatus: false,
+      BuildSpec: JSON.stringify({
+        "version": "0.2",
+        "phases": {
+          "pre_build": {
+            "commands": [
+              "git config --global user.email \"email@email\"",
+              "git config --global user.name \"user\""
+            ]
+          },
+          "build": {
+            "commands": [
+              "git describe --exact-match HEAD && { echo \"No new commits.\"; export SKIP=true; } || { echo \"Changes to release.\"; export SKIP=false; }",
+              "$SKIP || { /bin/sh ./bump.sh; }",
+              "$SKIP || aws secretsmanager get-secret-value --secret-id \"ssh-key-secret-arn\" --output=text --query=SecretString > ~/.ssh/id_rsa",
+              "$SKIP || mkdir -p ~/.ssh",
+              "$SKIP || chmod 0600 ~/.ssh/id_rsa",
+              "$SKIP || chmod 0600 ~/.ssh/config",
+              "$SKIP || ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts",
+              "$SKIP || { export VERSION=$(git describe) ; }",
+              "$SKIP || { export BRANCH=bump/$VERSION ; }",
+              "$SKIP || { git branch -D $BRANCH || true ; }",
+              "$SKIP || { git checkout -b $BRANCH ; }",
+              "$SKIP || { git remote add origin_ssh git@github.com:owner/repo.git ; }",
+              "$SKIP || { git push --follow-tags origin_ssh $BRANCH ; }"
+            ]
+          }
+        }
+      }, undefined, 2)
+    }
+  });
+});
+
+test('autoBump with schedule disabled', () => {
+  // GIVEN
+  const stack = new Stack();
+
+  // WHEN
+  new AutoBump(stack, 'MyAutoBump', {
+    repo: MOCK_REPO,
+    scheduleExpression: 'disable'
+  });
+
+  // THEN
+  expect(stack).not.toHaveResource('AWS::Events::Rule', {
+    ScheduleExpression: "cron(0 12 * * ? *)"
+  });
+});
+
+test('autoBump with pull request', () => {
+  // GIVEN
+  const stack = new Stack();
+  const repo = new WritableGitHubRepo({
+    sshKeySecret: { secretArn: 'ssh-key-secret-arn' },
+    commitUsername: 'user',
+    commitEmail: 'email@email',
+    repository: 'owner/repo',
+    tokenSecretArn: 'token-secret-arn'
+  });
+
+  // WHEN
+  new AutoBump(stack, 'MyAutoBump', {
+    repo,
+    pullRequest: true
+  });
+
+  // THEN
+
+  // build project
+  expect(stack).toHaveResource('AWS::CodeBuild::Project', {
+    Triggers: {
+      Webhook: false
+    },
+    Source: {
+      Type: 'GITHUB',
+      GitCloneDepth: 0,
+      Location: "https://github.com/owner/repo.git",
+      ReportBuildStatus: false,
+      BuildSpec: JSON.stringify({
+        "version": "0.2",
+        "phases": {
+          "pre_build": {
+            "commands": [
+              "git config --global user.email \"email@email\"",
+              "git config --global user.name \"user\""
+            ]
+          },
+          "build": {
+            "commands": [
+              "git describe --exact-match HEAD && { echo \"No new commits.\"; export SKIP=true; } || { echo \"Changes to release.\"; export SKIP=false; }",
+              "$SKIP || { /bin/sh ./bump.sh; }",
+              "$SKIP || aws secretsmanager get-secret-value --secret-id \"ssh-key-secret-arn\" --output=text --query=SecretString > ~/.ssh/id_rsa",
+              "$SKIP || mkdir -p ~/.ssh",
+              "$SKIP || chmod 0600 ~/.ssh/id_rsa",
+              "$SKIP || chmod 0600 ~/.ssh/config",
+              "$SKIP || ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts",
+              "$SKIP || { export VERSION=$(git describe) ; }",
+              "$SKIP || { export BRANCH=bump/$VERSION ; }",
+              "$SKIP || { git branch -D $BRANCH || true ; }",
+              "$SKIP || { git checkout -b $BRANCH ; }",
+              "$SKIP || { git remote add origin_ssh git@github.com:owner/repo.git ; }",
+              "$SKIP || { git push --follow-tags origin_ssh $BRANCH ; }",
+              "$SKIP || { GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id \"token-secret-arn\" --output=text --query=SecretString) ; }",
+              "$SKIP || { curl -X POST --header \"Authorization: token $GITHUB_TOKEN\" --header \"Content-Type: application/json\" -d \"{\\\"title\\\":\\\"chore(release): $VERSION\\\",\\\"body\\\":\\\"see CHANGELOG\\\",\\\"base\\\":\\\"master\\\",\\\"head\\\":\\\"$BRANCH\\\"}\" https://api.github.com/repos/owner/repo/pulls ; }"
+            ]
+          }
+        }
+      }, undefined, 2)
+    }
+  });
+});
+
+test('autoBump with pull request with custom options', () => {
+  // GIVEN
+  const stack = new Stack();
+
+  // WHEN
+  new AutoBump(stack, 'MyAutoBump', {
+    repo: MOCK_REPO,
+
+    // no need to specify pullRequest:true if we specify options
+    pullRequestOptions: {
+      title: 'custom title',
+      body: 'custom body',
+      base: 'release'
+    }
+  });
+
+  // THEN
+
+  // build project
+  expect(stack).toHaveResource('AWS::CodeBuild::Project', {
+    Triggers: {
+      Webhook: false
+    },
+    Source: {
+      Type: 'GITHUB',
+      GitCloneDepth: 0,
+      Location: "https://github.com/owner/repo.git",
+      ReportBuildStatus: false,
+      BuildSpec: JSON.stringify({
+        "version": "0.2",
+        "phases": {
+          "pre_build": {
+            "commands": [
+              "git config --global user.email \"email@email\"",
+              "git config --global user.name \"user\""
+            ]
+          },
+          "build": {
+            "commands": [
+              "git describe --exact-match HEAD && { echo \"No new commits.\"; export SKIP=true; } || { echo \"Changes to release.\"; export SKIP=false; }",
+              "$SKIP || { /bin/sh ./bump.sh; }",
+              "$SKIP || aws secretsmanager get-secret-value --secret-id \"ssh-key-secret-arn\" --output=text --query=SecretString > ~/.ssh/id_rsa",
+              "$SKIP || mkdir -p ~/.ssh",
+              "$SKIP || chmod 0600 ~/.ssh/id_rsa",
+              "$SKIP || chmod 0600 ~/.ssh/config",
+              "$SKIP || ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts",
+              "$SKIP || { export VERSION=$(git describe) ; }",
+              "$SKIP || { export BRANCH=bump/$VERSION ; }",
+              "$SKIP || { git branch -D $BRANCH || true ; }",
+              "$SKIP || { git checkout -b $BRANCH ; }",
+              "$SKIP || { git remote add origin_ssh git@github.com:owner/repo.git ; }",
+              "$SKIP || { git push --follow-tags origin_ssh $BRANCH ; }",
+              "$SKIP || { GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id \"token-secret-arn\" --output=text --query=SecretString) ; }",
+              "$SKIP || { curl -X POST --header \"Authorization: token $GITHUB_TOKEN\" --header \"Content-Type: application/json\" -d \"{\\\"title\\\":\\\"custom title\\\",\\\"body\\\":\\\"custom body\\\",\\\"base\\\":\\\"release\\\",\\\"head\\\":\\\"$BRANCH\\\"}\" https://api.github.com/repos/owner/repo/pulls ; }"
+            ]
+          }
+        }
+      }, undefined, 2)
+    }
+  });
+});
+
+test('autoBump with pull request fails when head=base', () => {
+  // GIVEN
+  const stack = new Stack();
+
+  // WHEN
+  expect(() => new AutoBump(stack, 'MyAutoBump', {
+    repo: MOCK_REPO,
+    branch: 'master',
+    pullRequestOptions: {
+      base: 'master'
+    }
+  })).toThrow();
+});

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -3766,18 +3766,19 @@ Resources:
                   "$SKIP || chmod 0600 ~/.ssh/id_rsa",
                   "$SKIP || chmod 0600 ~/.ssh/config",
                   "$SKIP || ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts",
-                  "$SKIP || { export TAG=$(git describe) ; }",
-                  "$SKIP || { export BRANCH=bump/$TAG ; }",
+                  "$SKIP || { export VERSION=$(git describe) ; }",
+                  "$SKIP || { export BRANCH=bump/$VERSION ; }",
                   "$SKIP || { git branch -D $BRANCH || true ; }",
                   "$SKIP || { git checkout -b $BRANCH ; }",
                   "$SKIP || { git remote add origin_ssh git@github.com:awslabs/aws-delivlib-sample.git ; }",
                   "$SKIP || { git push --follow-tags origin_ssh $BRANCH ; }",
                   "$SKIP || { GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id \"arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW\" --output=text --query=SecretString) ; }",
-                  "$SKIP || { curl -X POST --header \"Authorization: token $GITHUB_TOKEN\" --header \"Content-Type: application/json\" -d \"{\\\"title\\\":\\\"chore(release): $TAG\\\",\\\"body\\\":\\\"see CHANGELOG\\\",\\\"base\\\":\\\"master\\\",\\\"head\\\":\\\"$BRANCH\\\"}\" https://api.github.com/repos/awslabs/aws-delivlib-sample/pulls ; }"
+                  "$SKIP || { curl -X POST --header \"Authorization: token $GITHUB_TOKEN\" --header \"Content-Type: application/json\" -d \"{\\\"title\\\":\\\"chore(release): $VERSION\\\",\\\"body\\\":\\\"see CHANGELOG\\\",\\\"base\\\":\\\"master\\\",\\\"head\\\":\\\"$BRANCH\\\"}\" https://api.github.com/repos/awslabs/aws-delivlib-sample/pulls ; }"
                 ]
               }
             }
           }
+        GitCloneDepth: 0
         Location: https://github.com/awslabs/aws-delivlib-sample.git
         ReportBuildStatus: false
         Type: GITHUB

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -466,7 +466,7 @@ Resources:
                 Owner: awslabs
                 Repo: aws-delivlib-sample
                 Branch: master
-                OAuthToken: "{{resolve:secretsmanager:github-token:SecretString:::}}"
+                OAuthToken: "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW:SecretString:::}}"
                 PollForSourceChanges: false
               Name: Pull
               OutputArtifacts:
@@ -690,7 +690,7 @@ Resources:
     Properties:
       Authentication: GITHUB_HMAC
       AuthenticationConfiguration:
-        SecretToken: "{{resolve:secretsmanager:github-token:SecretString:::}}"
+        SecretToken: "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW:SecretString:::}}"
       Filters:
         - JsonPath: $.ref
           MatchEquals: refs/heads/{Branch}
@@ -3221,7 +3221,7 @@ Resources:
                 - SecretArn
           - Name: GITHUB_TOKEN
             Type: PLAINTEXT
-            Value: "{{resolve:secretsmanager:github-token:SecretString:::}}"
+            Value: "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW:SecretString:::}}"
           - Name: GITHUB_OWNER
             Type: PLAINTEXT
             Value: awslabs
@@ -3719,6 +3719,12 @@ Resources:
               - secretsmanager:GetSecretValue
             Effect: Allow
             Resource: arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/github-ssh-lwzfjW
+          - Action:
+              - secretsmanager:ListSecrets
+              - secretsmanager:DescribeSecret
+              - secretsmanager:GetSecretValue
+            Effect: Allow
+            Resource: arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW
         Version: "2012-10-17"
       PolicyName: CodeCommitPipelineAutoBumpRoleDefaultPolicyD6024577
       Roles:
@@ -3760,13 +3766,14 @@ Resources:
                   "$SKIP || chmod 0600 ~/.ssh/id_rsa",
                   "$SKIP || chmod 0600 ~/.ssh/config",
                   "$SKIP || ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts",
-                  "$SKIP || { BRANCH=bump/$(git describe) ; }",
+                  "$SKIP || { export TAG=$(git describe) ; }",
+                  "$SKIP || { export BRANCH=bump/$TAG ; }",
                   "$SKIP || { git branch -D $BRANCH || true ; }",
                   "$SKIP || { git checkout -b $BRANCH ; }",
-                  "$SKIP || { git checkout master ; }",
-                  "$SKIP || { git merge $BRANCH ; }",
                   "$SKIP || { git remote add origin_ssh git@github.com:awslabs/aws-delivlib-sample.git ; }",
-                  "$SKIP || { git push --follow-tags origin_ssh master ; }"
+                  "$SKIP || { git push --follow-tags origin_ssh $BRANCH ; }",
+                  "$SKIP || { GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id \"arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW\" --output=text --query=SecretString) ; }",
+                  "$SKIP || { curl -X POST --header \"Authorization: token $GITHUB_TOKEN\" --header \"Content-Type: application/json\" -d \"{\\\"title\\\":\\\"chore(release): $TAG\\\",\\\"body\\\":\\\"see CHANGELOG\\\",\\\"base\\\":\\\"master\\\",\\\"head\\\":\\\"$BRANCH\\\"}\" https://api.github.com/repos/awslabs/aws-delivlib-sample/pulls ; }"
                 ]
               }
             }
@@ -3778,53 +3785,6 @@ Resources:
         Webhook: false
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBump/Bump/Resource
-  CodeCommitPipelineAutoBumpEventsRole63A4AC28:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: sts:AssumeRole
-            Effect: Allow
-            Principal:
-              Service: events.amazonaws.com
-        Version: "2012-10-17"
-    Metadata:
-      aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBump/Bump/EventsRole/Resource
-  CodeCommitPipelineAutoBumpEventsRoleDefaultPolicy20B2B829:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action: codebuild:StartBuild
-            Effect: Allow
-            Resource:
-              Fn::GetAtt:
-                - CodeCommitPipelineAutoBumpA6619552
-                - Arn
-        Version: "2012-10-17"
-      PolicyName: CodeCommitPipelineAutoBumpEventsRoleDefaultPolicy20B2B829
-      Roles:
-        - Ref: CodeCommitPipelineAutoBumpEventsRole63A4AC28
-    Metadata:
-      aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBump/Bump/EventsRole/DefaultPolicy/Resource
-  CodeCommitPipelineAutoBumpSchedulerC4D05D9B:
-    Type: AWS::Events::Rule
-    Properties:
-      Description: Schedules an automatic bump for this repository
-      ScheduleExpression: cron(0 12 * * ? *)
-      State: ENABLED
-      Targets:
-        - Arn:
-            Fn::GetAtt:
-              - CodeCommitPipelineAutoBumpA6619552
-              - Arn
-          Id: Target0
-          RoleArn:
-            Fn::GetAtt:
-              - CodeCommitPipelineAutoBumpEventsRole63A4AC28
-              - Arn
-    Metadata:
-      aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBump/Scheduler/Resource
   CodeCommitPipelineAutoBumpBumpFailedAlarm47B5C467:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -3920,7 +3880,7 @@ Resources:
       Parameters:
         CodeBuildProjectName:
           Ref: CodeCommitPipelineAutoBuildProject5D212EE9
-        GitHubOAuthToken: "{{resolve:secretsmanager:github-token:SecretString:::}}"
+        GitHubOAuthToken: "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW:SecretString:::}}"
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBuild/GitHubCodeBuildLogsSAR
   CodeCommitPipelineChangeControllerCalendar94B1DEA8:

--- a/test/test-stack.ts
+++ b/test/test-stack.ts
@@ -17,7 +17,7 @@ export class TestStack extends cdk.Stack {
 
     const githubRepo = new delivlib.WritableGitHubRepo({
       repository: 'awslabs/aws-delivlib-sample',
-      token: cdk.SecretValue.secretsManager('github-token'),
+      tokenSecretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW',
       sshKeySecret: { secretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/github-ssh-lwzfjW' },
       commitEmail: 'foo@bar.com',
       commitUsername: 'foobar',
@@ -165,8 +165,9 @@ export class TestStack extends cdk.Stack {
     // BUMP
 
     pipeline.autoBump({
+      scheduleExpression: 'disable',
       bumpCommand: 'npm i && npm run bump',
-      branch: 'master'
+      pullRequest: true
     });
 
     //


### PR DESCRIPTION
Add support for automatically creating pull requests for bumps.

This requires the GitHub token to be available during bump. However, currently we model the GitHub token as a SecretValue, which resolves during deployment (by CloudFormation). This is not secure because it will pass the secret itself as environment variables. To address this, we changed `token` to `tokenSecretArn` and resolve it as needed (either during deployment if it’s required for a CFN definition or during runtime by extracting it from secrets manager).

BREAKING CHANGE: `repo.token` is now `tokenSecretArn` to enforce that the token is kept in AWS SecretsManager. Also, the API for `IRepo.createBuildSource` was modified.
