### PR TITLE
chore(pipeline): configure name and expose build project

### DIFF
--- a/test/expected.yml
+++ b/test/expected.yml
@@ -1217,6 +1217,11 @@ Resources:
         Fn::GetAtt:
           - CodeCommitPipelineBuildPipelineArtifactsBucketEncryptionKey05A62A83
           - Arn
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: CodeCommitPipelineBuildPipeline656B8CCB
+            - -Build
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/BuildProject/Resource
   CodeCommitPipelineBuildProjectOnBuildFailed2A08058D:

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -1,5 +1,10 @@
-// tslint:disable-next-line: max-line-length
-import { aws_codebuild as codebuild, aws_codecommit as codecommit, aws_codepipeline as cpipeline, aws_codepipeline_actions as cpipeline_actions, core as cdk } from "monocdk-experiment";
+import {
+  aws_codebuild as codebuild,
+  aws_codecommit as codecommit,
+  aws_codepipeline as cpipeline,
+  aws_codepipeline_actions as cpipeline_actions,
+  core as cdk
+} from "monocdk-experiment";
 import { expect as cdk_expect, haveResource, haveResourceLike, SynthUtils } from "@monocdk-experiment/assert";
 import path = require("path");
 import delivlib = require("../lib");


### PR DESCRIPTION
Exposing the CodeBuild project in the pipeline will enable use cases
around creating monitoring resources. As an example, the build's
Duration and Failure metrics can be graphed on a CloudWatch dashboard.

Having a concrete name to the CodeBuild Project allows for the above
mentioned dashboards to reliably graph these across syntheses.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
