### PR TITLE
fix(pipeline): cyclic dependency between CodePipeline::Pipeline and CodeBuild::Project

### DIFF
--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -64,7 +64,7 @@ export interface PipelineProps {
 
   /**
    * The name of the CodeBuild project that will be part of this pipeline.
-   * @default `${pipelineName}-Build`
+   * @default - `${pipelineName}-Build`, if `pipelineName` property is specified; automatically generated, otherwise.
    */
   buildProjectName?: string;
 
@@ -195,7 +195,10 @@ export class Pipeline extends cdk.Construct {
     this.buildEnvironment = createBuildEnvironment(props);
     this.buildSpec = props.buildSpec;
 
-    const buildProjectName = props.buildProjectName ?? `${this.pipeline.pipelineName}-Build`;
+    let buildProjectName = props.buildProjectName;
+    if (buildProjectName === undefined && props.pipelineName !== undefined) {
+      buildProjectName = `${props.pipelineName}-Build`;
+    }
     this.buildProject = new cbuild.PipelineProject(this, 'BuildProject', {
       projectName: buildProjectName,
       environment: this.buildEnvironment,

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -1217,11 +1217,6 @@ Resources:
         Fn::GetAtt:
           - CodeCommitPipelineBuildPipelineArtifactsBucketEncryptionKey05A62A83
           - Arn
-      Name:
-        Fn::Join:
-          - ""
-          - - Ref: CodeCommitPipelineBuildPipeline656B8CCB
-            - -Build
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/BuildProject/Resource
   CodeCommitPipelineBuildProjectOnBuildFailed2A08058D:

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -5,7 +5,7 @@ import {
   aws_codepipeline_actions as cpipeline_actions,
   core as cdk
 } from "monocdk-experiment";
-import { expect as cdk_expect, haveResource, haveResourceLike, SynthUtils } from "@monocdk-experiment/assert";
+import { expect as cdk_expect, haveResource, haveResourceLike, SynthUtils, ABSENT } from "@monocdk-experiment/assert";
 import path = require("path");
 import delivlib = require("../lib");
 import { AddToPipelineOptions, IPublisher } from "../lib";
@@ -263,6 +263,54 @@ test('autoBuild() can be configured with a different buildspec', () => {
       },
       Type: "CODECOMMIT",
     }
+  }));
+});
+
+test('CodeBuild Project name matches buildProjectName property', () => {
+  // GIVEN
+  const stack = new cdk.Stack();
+
+  // WHEN
+  new delivlib.Pipeline(stack, 'Pipeline', {
+    repo: createTestRepo(stack),
+    pipelineName: 'HelloPipeline',
+    buildProjectName: 'HelloBuild',
+  });
+
+  // THEN
+  cdk_expect(stack).to(haveResourceLike('AWS::CodeBuild::Project', {
+    Name: 'HelloBuild'
+  }));
+});
+
+test('CodeBuild Project name is extended from pipelineName property', () => {
+  // GIVEN
+  const stack = new cdk.Stack();
+
+  // WHEN
+  new delivlib.Pipeline(stack, 'Pipeline', {
+    repo: createTestRepo(stack),
+    pipelineName: 'HelloPipeline',
+  });
+
+  // THEN
+  cdk_expect(stack).to(haveResourceLike('AWS::CodeBuild::Project', {
+    Name: 'HelloPipeline-Build'
+  }));
+});
+
+test('CodeBuild Project name is left undefined when neither buildProjectName nor pipelineName are specified', () => {
+  // GIVEN
+  const stack = new cdk.Stack();
+
+  // WHEN
+  new delivlib.Pipeline(stack, 'Pipeline', {
+    repo: createTestRepo(stack),
+  });
+
+  // THEN
+  cdk_expect(stack).to(haveResourceLike('AWS::CodeBuild::Project', {
+    Name: ABSENT,
   }));
 });
 


### PR DESCRIPTION
This was accidentally introduced in a prior commit, which causes the
build project to depend on the pipeline for its name, while the pipeline
depends on the build project as part of its actions.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
