### PR TITLE
chore: we don't use grunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,6 @@ coverage
 # nyc test coverage
 .nyc_output
 
-# Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
-.grunt
-
 # Bower dependency directory (https://bower.io/)
 bower_components
 


### PR DESCRIPTION
Get rid of Grunt in gitignore.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
