### PR TITLE
feat(auto-build): delete previous links to build logs

### DIFF
--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -27,6 +27,16 @@ export interface AutoBuildOptions {
    */
   readonly publicLogs?: boolean;
 
+  /**
+   * Whether to delete previously published links to build logs
+   * before posting a new one.
+   *
+   * @see https://github.com/jlhood/github-codebuild-logs#app-parameters
+   *
+   * @default true
+   */
+  readonly deletePreviousPublicLogsLinks?: boolean;
+
   /* tslint:disable:max-line-length */
   /**
    * Build spec file to use for AutoBuild
@@ -76,6 +86,7 @@ export class AutoBuild extends core.Construct {
         },
         parameters: {
           CodeBuildProjectName: project.projectName,
+          DeletePreviousComments: (props.deletePreviousPublicLogsLinks ?? true).toString(),
           ...githubToken ? { GitHubOAuthToken: Token.asString(githubToken)} : undefined,
         }
       });

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -3889,6 +3889,7 @@ Resources:
       Parameters:
         CodeBuildProjectName:
           Ref: CodeCommitPipelineAutoBuildProject5D212EE9
+        DeletePreviousComments: "true"
         GitHubOAuthToken: "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW:SecretString:::}}"
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBuild/GitHubCodeBuildLogsSAR


### PR DESCRIPTION
Delete previously published links to build logs before posting a new one
in the GitHub PR discussion. This avoids bloating PR comments which can
make review difficult.

See https://github.com/jlhood/github-codebuild-logs/pull/21 and
https://github.com/aws/aws-cdk/issues/5522.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
