### PR TITLE
feat: recurring event support for change controller

### DIFF
--- a/change-control-lambda/test/time-window.test.ts
+++ b/change-control-lambda/test/time-window.test.ts
@@ -30,6 +30,15 @@ DTEND:20190204T075900Z
 SUMMARY:Block3
 END:VEVENT
 
+BEGIN:VEVENT
+RRULE:FREQ=WEEKLY;INTERVAL=1
+DTEND:20200504T170000Z
+SUMMARY:Block4
+DTSTAMP:20200501T163641Z
+DTSTART:20200501T220000Z
+SEQUENCE:0
+END:VEVENT
+
 END:VCALENDAR
 `;
 
@@ -57,4 +66,29 @@ test('a blocked window starts AND finishes within margin', () => {
   // Using 72 hours padding to widely overlap Block3
   const x = shouldBlockPipeline(ics, new Date('2019-02-03T07:00:00.000Z'), 72 * 3_600);
   expect(x && x.summary).toBe('Block3');
+});
+
+test('left edge for recurring event after the initial event', () => {
+  const x = shouldBlockPipeline(ics, new Date('2020-05-08T22:00:00.000Z'));
+  expect(x && x.summary).toBe('Block4 2020-05-08T22:00:00.000Z - 2020-05-11T17:00:00.000Z');
+});
+
+test('right edge for recurring event after the initial event', () => {
+  const x = shouldBlockPipeline(ics, new Date('2020-05-11T17:00:00.000Z'));
+  expect(x && x.summary).toBe('Block4 2020-05-08T22:00:00.000Z - 2020-05-11T17:00:00.000Z');
+});
+
+test('left edge for initial event in recurring event', () => {
+  const x = shouldBlockPipeline(ics, new Date('2020-05-01T22:00:00.000Z'));
+  expect(x && x.summary).toBe('Block4 2020-05-01T22:00:00.000Z - 2020-05-04T17:00:00.000Z');
+});
+
+test('right edge for initial event in recurring event', () => {
+  const x = shouldBlockPipeline(ics, new Date('2020-05-04T17:00:00.000Z'));
+  expect(x && x.summary).toBe('Block4 2020-05-01T22:00:00.000Z - 2020-05-04T17:00:00.000Z');
+});
+
+test('does not block in between recurrences', () => {
+  const x = shouldBlockPipeline(ics, new Date('2020-05-14T00:00:00.000Z'));
+  expect(x).toBeUndefined();
 });

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -3988,7 +3988,7 @@ Resources:
     Properties:
       Code:
         S3Bucket:
-          Ref: AssetParameters500f8decc1b07a07a0b491b58f62d27f29e3c5722173607732dbf9ac1af35743S3BucketCAD95EA9
+          Ref: AssetParameters0325c38481a47ea8f294cf6944b029039b69bda08b9ba364e516991c2e3844d2S3Bucket1EB09787
         S3Key:
           Fn::Join:
             - ""
@@ -3996,12 +3996,12 @@ Resources:
                   - 0
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters500f8decc1b07a07a0b491b58f62d27f29e3c5722173607732dbf9ac1af35743S3VersionKeyB72B1BB6
+                      - Ref: AssetParameters0325c38481a47ea8f294cf6944b029039b69bda08b9ba364e516991c2e3844d2S3VersionKey74F0473F
               - Fn::Select:
                   - 1
                   - Fn::Split:
                       - "||"
-                      - Ref: AssetParameters500f8decc1b07a07a0b491b58f62d27f29e3c5722173607732dbf9ac1af35743S3VersionKeyB72B1BB6
+                      - Ref: AssetParameters0325c38481a47ea8f294cf6944b029039b69bda08b9ba364e516991c2e3844d2S3VersionKey74F0473F
       Handler: index.handler
       Role:
         Fn::GetAtt:
@@ -4818,13 +4818,13 @@ Parameters:
   AssetParametersdc8eddab035b83a69e3f916300dc1f93dc508e78e729182de9f019cc8ffd7e3aArtifactHash4FC2FBD6:
     Type: String
     Description: Artifact hash for asset "dc8eddab035b83a69e3f916300dc1f93dc508e78e729182de9f019cc8ffd7e3a"
-  AssetParameters500f8decc1b07a07a0b491b58f62d27f29e3c5722173607732dbf9ac1af35743S3BucketCAD95EA9:
+  AssetParameters0325c38481a47ea8f294cf6944b029039b69bda08b9ba364e516991c2e3844d2S3Bucket1EB09787:
     Type: String
-    Description: S3 bucket for asset "500f8decc1b07a07a0b491b58f62d27f29e3c5722173607732dbf9ac1af35743"
-  AssetParameters500f8decc1b07a07a0b491b58f62d27f29e3c5722173607732dbf9ac1af35743S3VersionKeyB72B1BB6:
+    Description: S3 bucket for asset "0325c38481a47ea8f294cf6944b029039b69bda08b9ba364e516991c2e3844d2"
+  AssetParameters0325c38481a47ea8f294cf6944b029039b69bda08b9ba364e516991c2e3844d2S3VersionKey74F0473F:
     Type: String
-    Description: S3 key for asset version "500f8decc1b07a07a0b491b58f62d27f29e3c5722173607732dbf9ac1af35743"
-  AssetParameters500f8decc1b07a07a0b491b58f62d27f29e3c5722173607732dbf9ac1af35743ArtifactHashDBE8A4B1:
+    Description: S3 key for asset version "0325c38481a47ea8f294cf6944b029039b69bda08b9ba364e516991c2e3844d2"
+  AssetParameters0325c38481a47ea8f294cf6944b029039b69bda08b9ba364e516991c2e3844d2ArtifactHash797C5DAB:
     Type: String
-    Description: Artifact hash for asset "500f8decc1b07a07a0b491b58f62d27f29e3c5722173607732dbf9ac1af35743"
+    Description: Artifact hash for asset "0325c38481a47ea8f294cf6944b029039b69bda08b9ba364e516991c2e3844d2"
 


### PR DESCRIPTION
This change implements this feature request: https://github.com/awslabs/aws-delivlib/issues/331

#### Motivation & Use Case
We use the ChangeController to enable and disable stage transitions in our pipeline based on a calendar of events. This works well when events are singular, however we'd also like to enforce change control on recurring events. For instance, we want to block stage transition into production waves after hours and on weekends.

Sample event for weekends:
```
BEGIN:VEVENT
RRULE:FREQ=WEEKLY;INTERVAL=1
DTEND:20200511T170000Z
SUMMARY:Outside of business hours (weekend)
DTSTAMP:20200504T163641Z
DTSTART:20200508T220000Z
SEQUENCE:0
END:VEVENT
```

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
