### PR TITLE
npm --access=restricted now supported

### DIFF
--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -105,6 +105,12 @@ export interface PublishToNpmProjectProps {
    * @default - npm default behavior ("latest" unless dist tag is specified in package.json)
    */
   distTag?: string;
+  /**
+   * npm --access public|restricted
+   *
+   * @default 'public'
+   */
+  access?: string;
 }
 
 /**
@@ -119,6 +125,11 @@ export class PublishToNpmProject extends cdk.Construct implements IPublisher {
 
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
+    const access = props.access || 'public';
+    if (access != 'public' && access != 'restricted') {
+      throw new Error (`Unrecognized access type: ${access}`);
+    }
+
     const shellable = new Shellable(this, 'Default', {
       platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_10_1_0),
       scriptDirectory: path.join(__dirname, 'publishing', 'npm'),
@@ -126,7 +137,8 @@ export class PublishToNpmProject extends cdk.Construct implements IPublisher {
       environment: {
         FOR_REAL: forReal,
         NPM_TOKEN_SECRET: props.npmTokenSecret.secretArn,
-        DISTTAG: props.distTag || ''
+        DISTTAG: props.distTag || '',
+        ACCESS: access,
       },
     });
 

--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -10,8 +10,10 @@ import { WritableGitHubRepo } from "./repo";
 import { LinuxPlatform, Shellable } from "./shellable";
 import { noUndefined } from "./util";
 
-
-
+export enum NpmAccess {
+  PUBLIC = 'public',
+  RESTRICTED = 'restricted',
+}
 
 export interface PublishToMavenProjectProps {
   /**
@@ -108,9 +110,9 @@ export interface PublishToNpmProjectProps {
   /**
    * npm --access public|restricted
    *
-   * @default 'public'
+   * @default NpmAccess.PUBLIC
    */
-  access?: string;
+  access?: NpmAccess;
 }
 
 /**
@@ -125,10 +127,7 @@ export class PublishToNpmProject extends cdk.Construct implements IPublisher {
 
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
-    const access = props.access || 'public';
-    if (access != 'public' && access != 'restricted') {
-      throw new Error (`Unrecognized access type: ${access}`);
-    }
+    const access = props.access || NpmAccess.PUBLIC;
 
     const shellable = new Shellable(this, 'Default', {
       platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_10_1_0),

--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -127,7 +127,7 @@ export class PublishToNpmProject extends cdk.Construct implements IPublisher {
 
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
-    const access = props.access || NpmAccess.PUBLIC;
+    const access = props.access ?? NpmAccess.PUBLIC;
 
     const shellable = new Shellable(this, 'Default', {
       platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_10_1_0),

--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -10,8 +10,18 @@ import { WritableGitHubRepo } from "./repo";
 import { LinuxPlatform, Shellable } from "./shellable";
 import { noUndefined } from "./util";
 
+/**
+ * Type of access permissions to request from npmjs.
+ */
 export enum NpmAccess {
+  /**
+   * No access restriction. Note that unscoped packages must always be public.
+   */
   PUBLIC = 'public',
+
+  /**
+   * Limit access to whitelisted npmjs users.
+   */
   RESTRICTED = 'restricted',
 }
 
@@ -107,8 +117,15 @@ export interface PublishToNpmProjectProps {
    * @default - npm default behavior ("latest" unless dist tag is specified in package.json)
    */
   distTag?: string;
+
   /**
    * npm --access public|restricted
+   *
+   * See https://docs.npmjs.com/cli-commands/publish#:~:text=Tells%20the
+   *
+   * Tells the registry whether this package should be published as public or restricted.
+   * Only applies to scoped packages, which default to restricted.
+   * If you don’t have a paid account, you must publish with --access public to publish scoped packages.
    *
    * @default NpmAccess.PUBLIC
    */

--- a/lib/publishing/npm/publish-npm.sh
+++ b/lib/publishing/npm/publish-npm.sh
@@ -27,6 +27,11 @@ if [ -n "${DISTTAG}" ]; then
     DISTTAG="--tag=${DISTTAG}"
 fi
 
+ACCESS="${ACCESS:-"public"}"
+if [ -n "$ACCESS" ]; then
+    ACCESS=public
+fi
+
 echo "📦 Publishing to NPM"
 
 TOKENS=$(npm token list 2>&1 || echo '')
@@ -51,7 +56,7 @@ for TGZ in $(find ${PWD}/js -iname '*.tgz'); do
     # returns an empty string if the package exists, but version doesn't
     npm_view=$(npm view ${mod}@${ver} 2> /dev/null || true)
     if [ -z "${npm_view}" ]; then
-        $dry_npm publish $TGZ --access=public ${DISTTAG} --loglevel=silly
+        $dry_npm publish $TGZ --access=${ACCESS} ${DISTTAG} --loglevel=silly
     else
         echo "⚠️ Package ${mod}@${ver} already published. Skipping."
     fi

--- a/test/test-stack.ts
+++ b/test/test-stack.ts
@@ -106,7 +106,7 @@ export class TestStack extends cdk.Stack {
 
     pipeline.publishToNpm({
       npmTokenSecret: { secretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/npm-OynG62' },
-      access: 'restricted',
+      access: delivlib.NpmAccess.RESTRICTED,
     });
 
     // this creates a self-signed certificate

--- a/test/test-stack.ts
+++ b/test/test-stack.ts
@@ -105,7 +105,8 @@ export class TestStack extends cdk.Stack {
     //
 
     pipeline.publishToNpm({
-      npmTokenSecret: { secretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/npm-OynG62' }
+      npmTokenSecret: { secretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/npm-OynG62' },
+      access: 'restricted',
     });
 
     // this creates a self-signed certificate


### PR DESCRIPTION
Default to access=public so we don't change existing behavior.

resolves https://github.com/awslabs/aws-delivlib/issues/368

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.