### PR TITLE
feat: allow setting a timeout for Shellable

### DIFF
--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -91,6 +91,13 @@ export interface ShellableOptions {
   buildSpec?: BuildSpec;
 
   /**
+   * The timeout of the build.
+   *
+   * @default the CodeBuild default (1 hour)
+   */
+  timeout?: cdk.Duration;
+
+  /**
    * Alarm period.
    *
    * @default 300 seconds (5 minutes)
@@ -238,6 +245,7 @@ export class Shellable extends cdk.Construct {
         ...renderEnvironmentVariables(props.environmentSecrets, cbuild.BuildEnvironmentVariableType.SECRETS_MANAGER),
         ...renderEnvironmentVariables(props.environmentParameters, cbuild.BuildEnvironmentVariableType.PARAMETER_STORE),
       },
+      timeout: props.timeout,
       buildSpec: cbuild.BuildSpec.fromObject(this.buildSpec.render({ primaryArtifactName: this.outputArtifactName })),
     });
 


### PR DESCRIPTION
Useful when builds star to approach the default CodeBuild timeout of one hour.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
