### PR TITLE
feature: expose STS endpoint type

### DIFF
--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -78,6 +78,14 @@ export interface ShellableOptions {
   buildProjectName?: string;
 
   /**
+   * Indicates if Regional AWS STS endpoints should be used instead
+   * of the global endpoint. Specify true to use Regional AWS STS endpoints.
+   *
+   * @default false
+   */
+  useRegionalStsEndpoints?: boolean;
+
+  /**
    * Can be used to run this build using a specific IAM role. This can be used,
    * for example, to execute in the context of another account (e.g. to run
    * tests in isolation).
@@ -227,7 +235,7 @@ export class Shellable extends cdk.Construct {
     }
 
     this.buildSpec = BuildSpec.simple({
-      preBuild: this.platform.prebuildCommands(props.assumeRole),
+      preBuild: this.platform.prebuildCommands(props.assumeRole, props.useRegionalStsEndpoints),
       build: this.platform.buildCommands(props.entrypoint)
     }).merge(props.buildSpec || BuildSpec.empty());
 
@@ -330,7 +338,7 @@ export abstract class ShellPlatform {
   /**
    * Return commands to download the script bundle
    */
-  public abstract prebuildCommands(assumeRole?: AssumeRole): string[];
+  public abstract prebuildCommands(assumeRole?: AssumeRole, useRegionalStsEndpoints?: boolean): string[];
 
   /**
    * Return commands to start the entrypoint script
@@ -349,7 +357,7 @@ export abstract class ShellPlatform {
 export class LinuxPlatform extends ShellPlatform {
   public readonly platformType = PlatformType.Linux;
 
-  public prebuildCommands(assumeRole?: AssumeRole): string[] {
+  public prebuildCommands(assumeRole?: AssumeRole, useRegionalStsEndpoints?: boolean): string[] {
     const lines = new Array<string>();
     // Better echo the location here; if this fails, the error message only contains
     // the unexpanded variables by default. It might fail if you're running an old
@@ -362,8 +370,9 @@ export class LinuxPlatform extends ShellPlatform {
 
     if (assumeRole) {
       const externalId = assumeRole.externalId ? `--external-id "${assumeRole.externalId}"` : '';
+      const StsEndpoints = useRegionalStsEndpoints ? "regional" : "legacy";
       lines.push('creds=$(mktemp -d)/creds.json');
-      lines.push(`aws sts assume-role --role-arn "${assumeRole.roleArn}" --role-session-name "${assumeRole.sessionName}" ${externalId} > $creds`);
+      lines.push(`AWS_STS_REGIONAL_ENDPOINTS=${StsEndpoints} aws sts assume-role --role-arn "${assumeRole.roleArn}" --role-session-name "${assumeRole.sessionName}" ${externalId} > $creds`);
       lines.push('export AWS_ACCESS_KEY_ID="$(cat ${creds} | grep "AccessKeyId" | cut -d\'"\' -f 4)"');
       lines.push('export AWS_SECRET_ACCESS_KEY="$(cat ${creds} | grep "SecretAccessKey" | cut -d\'"\' -f 4)"');
       lines.push('export AWS_SESSION_TOKEN="$(cat ${creds} | grep "SessionToken" | cut -d\'"\' -f 4)"');
@@ -387,7 +396,7 @@ export class LinuxPlatform extends ShellPlatform {
 export class WindowsPlatform extends ShellPlatform {
   public readonly platformType = PlatformType.Windows;
 
-  public prebuildCommands(assumeRole?: AssumeRole): string[] {
+  public prebuildCommands(assumeRole?: AssumeRole, _useRegionalStsEndpoints?: boolean): string[] {
     if (assumeRole) {
       throw new Error(`assumeRole is not supported on Windows: https://github.com/awslabs/aws-delivlib/issues/57`);
     }

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -2067,7 +2067,7 @@ Resources:
                         "mkdir -p /tmp/scriptdir",
                         "unzip /tmp/$(basename $SCRIPT_S3_KEY) -d /tmp/scriptdir",
                         "creds=$(mktemp -d)/creds.json",
-                        "aws sts assume-role --role-arn \"
+                        "AWS_STS_REGIONAL_ENDPOINTS=legacy aws sts assume-role --role-arn \"
               - Fn::GetAtt:
                   - AssumeMe924099BB
                   - Arn


### PR DESCRIPTION
AWS STS deprecates the use of the global endpoint and all usage needs to be switched over to the regional endpoints.
As described in this issue: https://github.com/awslabs/aws-delivlib/issues/358, shellable's assumeRole Uses STS Global Endpoint.

This change resolves the issue using the environment variable `AWS_STS_REGIONAL_ENDPOINTS`. 

The default behavior will remain the same as `AWS_STS_REGIONAL_ENDPOINTS` will be set to value `legacy` and the calls will still go to the global endpoint. Although now we expose the boolean flag `useRegionalSTSEndpoints` and if it's set to `true`, then `AWS_STS_REGIONAL_ENDPOINTS=regional` will be used and the calls will go to the regional endpoints.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
