### PR TITLE
fix: make changes to RSA key construct path backwards compatible 

### DIFF
--- a/.github/workflows/auto-merge-prs.yml
+++ b/.github/workflows/auto-merge-prs.yml
@@ -6,10 +6,6 @@
 name: Automerge Completed PRs
 on:
   pull_request:
-    types:
-      - reopened
-      - unlocked
-      - unlabeled
   pull_request_review:
     types:
       - submitted

--- a/lib/code-signing/code-signing-certificate.ts
+++ b/lib/code-signing/code-signing-certificate.ts
@@ -56,6 +56,13 @@ interface CodeSigningCertificateProps {
    * The Distinguished Name for this CSR.
    */
   distinguishedName: DistinguishedName;
+
+  /**
+   * Base names for the private key and output SSM parameter
+   *
+   * @default - Automatically generated
+   */
+  readonly baseName?: string;
 }
 
 export interface ICodeSigningCertificate extends cdk.IConstruct, ICredentialPair {
@@ -95,8 +102,9 @@ export class CodeSigningCertificate extends cdk.Construct implements ICodeSignin
   constructor(parent: cdk.Construct, id: string, props: CodeSigningCertificateProps) {
     super(parent, id);
 
-    // The construct path of this construct, without any leading /
-    const baseName = this.node.path.replace(/^\/+/, '');
+    // The construct path of this construct with respect to the containing stack, without any leading /
+    const stack = cdk.Stack.of(this);
+    const baseName = props.baseName ?? `${stack.stackName}${this.node.path.substr(stack.node.path.length)}`;
 
     const privateKey = new RsaPrivateKeySecret(this, 'RSAPrivateKey', {
       removalPolicy: props.retainPrivateKey === false ? cdk.RemovalPolicy.DESTROY : cdk.RemovalPolicy.RETAIN,

--- a/test/code-signing-cert.test.ts
+++ b/test/code-signing-cert.test.ts
@@ -41,3 +41,19 @@ test('secret name consists of stack name and relative construct path', () => {
     SecretName: 'ActualStackName/Inbetween/Cert/RSAPrivateKey',
   });
 });
+
+
+test('secret name can be overridden', () => {
+  // WHEN
+  const yetAnotherParent = new cdk.Construct(stack, 'Inbetween');
+  new delivlib.CodeSigningCertificate(yetAnotherParent, 'Cert', {
+    distinguishedName,
+    pemCertificate: 'asdf',
+    secretEncryptionKey: key,
+    baseName: 'Sekrit',
+  });
+
+  expect(stack).toHaveResource('Custom::RsaPrivateKeySecret', {
+    SecretName: 'Sekrit/RSAPrivateKey',
+  });
+});

--- a/test/code-signing-cert.test.ts
+++ b/test/code-signing-cert.test.ts
@@ -1,0 +1,43 @@
+import { aws_kms as kms } from "monocdk-experiment";
+import * as cdk from 'monocdk-experiment';
+import "@monocdk-experiment/assert/jest";
+import * as delivlib from '../lib';
+
+
+let app: cdk.App;
+let stack: cdk.Stack;
+let key: kms.Key;
+beforeEach(() => {
+  app = new cdk.App();
+  const randomExtraContainer = new cdk.Construct(app, 'SomethingElse');
+  stack = new cdk.Stack(randomExtraContainer, 'Stack', {
+    stackName: 'ActualStackName',
+  });
+  key = new kms.Key(stack, 'Key');
+});
+
+const distinguishedName: delivlib.DistinguishedName = {
+  commonName: 'CN',
+  country: 'Country',
+  emailAddress: 'Email',
+  locality: 'Locality',
+  organizationName: 'OrgName',
+  organizationalUnitName: 'OrgUnitName',
+  stateOrProvince: 'Province, Please',
+};
+
+test('secret name consists of stack name and relative construct path', () => {
+  // WHEN
+  const yetAnotherParent = new cdk.Construct(stack, 'Inbetween');
+  new delivlib.CodeSigningCertificate(yetAnotherParent, 'Cert', {
+    distinguishedName,
+    pemCertificate: 'asdf',
+    secretEncryptionKey: key,
+  });
+
+  // THEN - specifically: does not include construct names above the containing stack
+  // uses the actual stack name (and not the stack NODE name)
+  expect(stack).toHaveResource('Custom::RsaPrivateKeySecret', {
+    SecretName: 'ActualStackName/Inbetween/Cert/RSAPrivateKey',
+  });
+});


### PR DESCRIPTION
The RSA key name used to be calculated off of the signing cert's
complete construct path.

This requires it to be replaced if the construct tree is refactored
(and specifically, if the location of the containing stack is moved,
such as it being moved into a `Stage`).

A name that is based off of the stack's deployment name and the
construct path *inside* the stack:

* is indifferent to the stack's location in the construct tree.
* is backwards compatible with simple setups.

For non-backwards compatible cases, the name is now also configurable.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
