### PR TITLE
fix(pr): AutoPR handle repos without master branch

### DIFF
--- a/lib/pull-request/pr.ts
+++ b/lib/pull-request/pr.ts
@@ -318,7 +318,7 @@ export class AutoPullRequest extends cdk.Construct {
       `&& { echo ".git directory exists";  } ` +
 
       // clone if it doesn't
-      `|| { echo ".git directory doesnot exist - cloning..." && git clone git@github.com:${this.props.repo.owner}/${this.props.repo.repo}.git /tmp/repo && mv /tmp/repo/.git . && git reset --hard master; }`,
+      `|| { echo ".git directory doesnot exist - cloning..." && git clone git@github.com:${this.props.repo.owner}/${this.props.repo.repo}.git /tmp/repo && mv /tmp/repo/.git . && git reset --hard ${this.baseBranch}; }`,
 
     ];
 

--- a/test/bump.test.ts
+++ b/test/bump.test.ts
@@ -262,7 +262,7 @@ test('autoBump with pull request with custom options', () => {
               "$SKIP || { chmod 0600 ~/.ssh/id_rsa ; }",
               "$SKIP || { chmod 0600 ~/.ssh/config ; }",
               "$SKIP || { ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts ; }",
-              "$SKIP || { ls .git && { echo \".git directory exists\";  } || { echo \".git directory doesnot exist - cloning...\" && git clone git@github.com:owner/repo.git /tmp/repo && mv /tmp/repo/.git . && git reset --hard master; } ; }",
+              "$SKIP || { ls .git && { echo \".git directory exists\";  } || { echo \".git directory doesnot exist - cloning...\" && git clone git@github.com:owner/repo.git /tmp/repo && mv /tmp/repo/.git . && git reset --hard release; } ; }",
               "$SKIP || { git describe --exact-match release && { echo 'Skip condition is met, skipping...' && export SKIP=true; } || { echo 'Skip condition is not met, continuing...' && export SKIP=false; } ; }",
               "$SKIP || { git rev-parse --verify origin/bump/$VERSION && { git checkout bump/$VERSION && git merge release && /bin/sh ./bump.sh && export VERSION=$(git describe) && echo Finished running user commands;  } || { git checkout release && git checkout -b temp && /bin/sh ./bump.sh && export VERSION=$(git describe) && echo Finished running user commands && git branch -m bump/$VERSION; } ; }",
               "$SKIP || { git remote add origin_ssh git@github.com:owner/repo.git ; }",


### PR DESCRIPTION
Updated the autoPR code that clones the repo if needed to work with repos that do not have a branch named master.

This resolves the issue https://github.com/awslabs/aws-delivlib/issues/450 and fixes AutoMergeBack MR's for repos that do not have a master branch.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
