### PR TITLE
fix: auto bump does not work for delivlib's own pipeline

### DIFF
--- a/pipeline/delivlib.ts
+++ b/pipeline/delivlib.ts
@@ -66,6 +66,9 @@ export class DelivLibPipelineStack extends cdk.Stack {
       scheduleExpression: 'cron(0 12 * * ? *)',
       bumpCommand: 'yarn install --frozen-lockfile && yarn bump',
       head: {
+        name: 'main',
+      },
+      base: {
         name: 'main'
       },
       pushOnly: true


### PR DESCRIPTION
This is due to our switch to the `main` branch instead of `master`.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
