### PR TITLE
chore(pipeline): refactor failure notification to use bind pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ pipeline.notifyOnFailure(PipelineNotification.slack({
 
 // Chime
 const teamRoomWebhook = 'https://hooks.chime.aws/incomingwebhooks/1c3588c7-623d-4799-af9b-8b1818fca779?token=cUMzOVA4OXl8MXxCaHJlZ0RUVm03TmZVMkpoTzlwa3NVbXJCam8tNWF3UGdzemVqZndsZERV';
-pipeline.notifyOnFailure(PipelineNotification.slack({
+pipeline.notifyOnFailure(PipelineNotification.chime({
   webhookUrl: [ teamRoomWebhook ]
 }));
 ```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ available:
    - [PyPi](#pypi)
    - [GitHub Releases](#github-releases)
    - [GitHub Pages](#github-pages)
+5. [Automatic Bumps and Pull Request Builds](#automatic-bumps-and-pull-request-builds)
+6. [Failure Notifications](#failure-notifications)
 
 
 ## Installation
@@ -693,6 +695,27 @@ If a bump fails, the `bump.alarm` CloudWatch alarm will be triggered.
 NOTE: there is currently no way for the bump command to indicate to the
 system that a bump is not needed (i.e. no changes have been made to the
 library).
+
+## Failure Notifications
+
+Pipelines can be configured with notifications that will be sent on any failure in pipeline's stages. Notifications can
+be sent to either a Slack channel or a Chime room. The following code configures one of each -
+
+```ts
+// Slack
+const teamChannel = new chatbot.SlackChannelConfiguration(this, {
+  // ...
+});
+pipeline.notifyOnFailure(PipelineNotification.slack({
+  channels: [teamChannel]
+}));
+
+// Chime
+const teamRoomWebhook = 'https://hooks.chime.aws/incomingwebhooks/1c3588c7-623d-4799-af9b-8b1818fca779?token=cUMzOVA4OXl8MXxCaHJlZ0RUVm03TmZVMkpoTzlwa3NVbXJCam8tNWF3UGdzemVqZndsZERV';
+pipeline.notifyOnFailure(PipelineNotification.slack({
+  webhookUrl: [ teamRoomWebhook ]
+}));
+```
 
 ## Contributing
 

--- a/lib/chime-notifier/chime-notifier.ts
+++ b/lib/chime-notifier/chime-notifier.ts
@@ -9,10 +9,7 @@ import {
   aws_events_targets as events_targets,
 } from 'monocdk';
 
-/**
- * Properties for a ChimeNotifier
- */
-export interface ChimeNotifierProps {
+export interface ChimeNotifierOptions {
   /**
    * Chime webhook URLs to send to
    */
@@ -31,7 +28,12 @@ export interface ChimeNotifierProps {
    * @default - A default message
    */
   readonly message?: string;
+}
 
+/**
+ * Properties for a ChimeNotifier
+ */
+export interface ChimeNotifierProps extends ChimeNotifierOptions {
   /**
    * Code Pipeline to listen to
    */

--- a/lib/chime-notifier/chime-notifier.ts
+++ b/lib/chime-notifier/chime-notifier.ts
@@ -65,7 +65,7 @@ export class ChimeNotifier extends Construct {
         resources: [props.pipeline.pipelineArn],
       }));
 
-      props.pipeline.onStateChange('ChimeOnFailure', {
+      props.pipeline.onStateChange(`ChimeOnFailure-${JSON.stringify(props.webhookUrls)}`, {
         target: new events_targets.LambdaFunction(notifierLambda, {
           event: events.RuleTargetInput.fromObject({
             // Add parameters

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,3 +12,4 @@ export * from './signing-key';
 export * from './code-signing';
 export * from './pull-request';
 export * from './chime-notifier';
+export * from './pipeline-notifications';

--- a/lib/pipeline-notifications/chime.ts
+++ b/lib/pipeline-notifications/chime.ts
@@ -1,0 +1,22 @@
+import { ChimeNotifier, ChimeNotifierOptions, IPipelineNotification, PipelineNotificationBindOptions } from '../';
+
+/**
+ * Properties to initialize ChimeNotification
+ */
+export interface ChimeNotificationProps extends ChimeNotifierOptions {
+}
+
+/**
+ * Notify events on pipeline to a Chime room.
+ */
+export class ChimeNotification implements IPipelineNotification {
+  constructor(private readonly props: ChimeNotificationProps) {
+  }
+
+  public bind(options: PipelineNotificationBindOptions): void {
+    new ChimeNotifier(options.pipeline, 'PipelineNotificationChime', {
+      ...this.props,
+      pipeline: options.codePipeline,
+    });
+  }
+}

--- a/lib/pipeline-notifications/chime.ts
+++ b/lib/pipeline-notifications/chime.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import { ChimeNotifier, ChimeNotifierOptions, IPipelineNotification, PipelineNotificationBindOptions } from '../';
 
 /**
@@ -14,9 +15,11 @@ export class ChimeNotification implements IPipelineNotification {
   }
 
   public bind(options: PipelineNotificationBindOptions): void {
-    new ChimeNotifier(options.pipeline, 'PipelineNotificationChime', {
+    const md5 = crypto.createHash('md5');
+    md5.update(JSON.stringify(this.props.webhookUrls));
+    new ChimeNotifier(options.pipeline, `PipelineNotificationChime-${md5.digest('hex')}`, {
       ...this.props,
-      pipeline: options.codePipeline,
+      pipeline: options.pipeline.pipeline,
     });
   }
 }

--- a/lib/pipeline-notifications/index.ts
+++ b/lib/pipeline-notifications/index.ts
@@ -1,0 +1,16 @@
+import { IPipelineNotification } from '../pipeline';
+import { ChimeNotification, ChimeNotificationProps } from './chime';
+import { SlackNotification, SlackNotificationProps } from './slack';
+
+export class PipelineNotification {
+  public static slack(props: SlackNotificationProps): IPipelineNotification {
+    return new SlackNotification(props);
+  }
+
+  public static chime(props: ChimeNotificationProps): IPipelineNotification {
+    return new ChimeNotification(props);
+  }
+}
+
+export * from './chime';
+export * from './slack';

--- a/lib/pipeline-notifications/slack.ts
+++ b/lib/pipeline-notifications/slack.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import {
   aws_chatbot as chatbot,
   aws_codestarnotifications as starnotifs,
@@ -31,10 +32,12 @@ export class SlackNotification implements IPipelineNotification {
         targetType: 'AWSChatbotSlack',
       };
     });
-    new starnotifs.CfnNotificationRule(options.pipeline, 'PipelineNotificationSlack', {
-      name: `${options.codePipeline.pipelineName}-failednotifications`,
+    const md5 = crypto.createHash('md5');
+    md5.update(JSON.stringify(targets));
+    new starnotifs.CfnNotificationRule(options.pipeline, `PipelineNotificationSlack-${md5.digest('hex')}`, {
+      name: `${options.pipeline.pipeline.pipelineName}-failednotifications`,
       detailType: 'BASIC',
-      resource: options.codePipeline.pipelineArn,
+      resource: options.pipeline.pipeline.pipelineArn,
       targets,
       eventTypeIds: ['codepipeline-pipeline-action-execution-failed'],
     });

--- a/lib/pipeline-notifications/slack.ts
+++ b/lib/pipeline-notifications/slack.ts
@@ -1,0 +1,42 @@
+import {
+  aws_chatbot as chatbot,
+  aws_codestarnotifications as starnotifs,
+} from 'monocdk';
+import { IPipelineNotification, PipelineNotificationBindOptions } from '../';
+
+/**
+ * Properties to initialize SlackNotification
+ */
+export interface SlackNotificationProps {
+  /**
+   * The list of Chatbot registered slack channels.
+   */
+  readonly channels: chatbot.SlackChannelConfiguration[];
+}
+
+/**
+ * Notify events on pipeline to a Slack channel via AWS Chatbot
+ */
+export class SlackNotification implements IPipelineNotification {
+  constructor(private readonly props: SlackNotificationProps) {
+    if (this.props.channels.length == 0) {
+      throw new Error('channels cannot be empty');
+    }
+  }
+
+  public bind(options: PipelineNotificationBindOptions): void {
+    const targets: starnotifs.CfnNotificationRule.TargetProperty[] = this.props.channels.map(c => {
+      return {
+        targetAddress: c.slackChannelConfigurationArn,
+        targetType: 'AWSChatbotSlack',
+      };
+    });
+    new starnotifs.CfnNotificationRule(options.pipeline, 'PipelineNotificationSlack', {
+      name: `${options.codePipeline.pipelineName}-failednotifications`,
+      detailType: 'BASIC',
+      resource: options.codePipeline.pipelineArn,
+      targets,
+      eventTypeIds: ['codepipeline-pipeline-action-execution-failed'],
+    });
+  }
+}

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -164,7 +164,6 @@ export interface PipelineProps {
 
 export interface PipelineNotificationBindOptions {
   readonly pipeline: Pipeline;
-  readonly codePipeline: cpipeline.Pipeline;
 }
 
 export interface IPipelineNotification {
@@ -219,7 +218,10 @@ export class Pipeline extends Construct {
    */
   public readonly buildProject: cbuild.IProject;
 
-  private readonly pipeline: cpipeline.Pipeline;
+  /**
+   * The underlying CodePipeline Pipeline object that models this pipeline.
+   */
+  public readonly pipeline: cpipeline.Pipeline;
   private readonly branch: string;
   private readonly notify?: sns.Topic;
   private stages: { [name: string]: cpipeline.IStage } = { };
@@ -298,7 +300,6 @@ export class Pipeline extends Construct {
 
   public notifyOnFailure(notification: IPipelineNotification) {
     notification.bind({
-      codePipeline: this.pipeline,
       pipeline: this,
     });
   }

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -4050,7 +4050,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: cdk-hnb659fds-assets-712950704752-us-east-1
-        S3Key: f0f5ba23ba9e566392373f5d62342d9e5acf689396d45b282dc56c9af5575034.zip
+        S3Key: 754b192f50fcd7e07ff2db430184f49d64a5b0c2e169db7cf705da7a05f80a0e.zip
       Handler: index.handler
       Role:
         Fn::GetAtt:

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -4050,7 +4050,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: cdk-hnb659fds-assets-712950704752-us-east-1
-        S3Key: 754b192f50fcd7e07ff2db430184f49d64a5b0c2e169db7cf705da7a05f80a0e.zip
+        S3Key: f0f5ba23ba9e566392373f5d62342d9e5acf689396d45b282dc56c9af5575034.zip
       Handler: index.handler
       Role:
         Fn::GetAtt:

--- a/test/pipeline-notifications/chime.test.ts
+++ b/test/pipeline-notifications/chime.test.ts
@@ -1,0 +1,40 @@
+import { stringLike } from '@monocdk-experiment/assert';
+import '@monocdk-experiment/assert/jest';
+import {
+  App, Stack,
+  aws_codecommit as codecommit,
+  aws_codepipeline as cpipeline,
+} from 'monocdk';
+import { Pipeline, CodeCommitRepo, ChimeNotification } from '../../lib';
+
+describe('slack notifications', () => {
+  test('failure notification via chime', () => {
+    // GIVEN
+    const stack = new Stack(new App(), 'TestStack');
+    const pipe = new Pipeline(stack, 'Pipeline', {
+      repo: new CodeCommitRepo(new codecommit.Repository(stack, 'Repo1', { repositoryName: 'test' })),
+    });
+
+    // WHEN
+    pipe.notifyOnFailure(new ChimeNotification({
+      webhookUrls: ['url-1'],
+    }));
+
+    // THEN
+    expect(stack).toHaveResourceLike('AWS::Events::Rule', {
+      EventPattern: {
+        source: ['aws.codepipeline'],
+        resources: [
+          stack.resolve((pipe.node.findChild('BuildPipeline') as cpipeline.Pipeline).pipelineArn),
+        ],
+      },
+      Targets: [
+        {
+          InputTransformer: {
+            InputTemplate: stringLike('*url-1*'),
+          },
+        },
+      ],
+    });
+  });
+});

--- a/test/pipeline-notifications/chime.test.ts
+++ b/test/pipeline-notifications/chime.test.ts
@@ -3,11 +3,10 @@ import '@monocdk-experiment/assert/jest';
 import {
   App, Stack,
   aws_codecommit as codecommit,
-  aws_codepipeline as cpipeline,
 } from 'monocdk';
 import { Pipeline, CodeCommitRepo, ChimeNotification } from '../../lib';
 
-describe('slack notifications', () => {
+describe('chime notifications', () => {
   test('failure notification via chime', () => {
     // GIVEN
     const stack = new Stack(new App(), 'TestStack');
@@ -25,13 +24,50 @@ describe('slack notifications', () => {
       EventPattern: {
         source: ['aws.codepipeline'],
         resources: [
-          stack.resolve((pipe.node.findChild('BuildPipeline') as cpipeline.Pipeline).pipelineArn),
+          stack.resolve(pipe.pipeline.pipelineArn),
         ],
       },
       Targets: [
         {
           InputTransformer: {
             InputTemplate: stringLike('*url-1*'),
+          },
+        },
+      ],
+    });
+  });
+
+  test('multiple chime notifications', () => {
+    // GIVEN
+    const stack = new Stack(new App(), 'TestStack');
+    const pipe = new Pipeline(stack, 'Pipeline', {
+      repo: new CodeCommitRepo(new codecommit.Repository(stack, 'Repo1', { repositoryName: 'test' })),
+    });
+
+    // WHEN
+    pipe.notifyOnFailure(new ChimeNotification({
+      webhookUrls: ['url-1'],
+    }));
+
+    pipe.notifyOnFailure(new ChimeNotification({
+      webhookUrls: ['url-2'],
+    }));
+
+    // THEN
+    expect(stack).toHaveResourceLike('AWS::Events::Rule', {
+      Targets: [
+        {
+          InputTransformer: {
+            InputTemplate: stringLike('*url-1*'),
+          },
+        },
+      ],
+    });
+    expect(stack).toHaveResourceLike('AWS::Events::Rule', {
+      Targets: [
+        {
+          InputTransformer: {
+            InputTemplate: stringLike('*url-2*'),
           },
         },
       ],

--- a/test/pipeline-notifications/slack.test.ts
+++ b/test/pipeline-notifications/slack.test.ts
@@ -1,0 +1,50 @@
+import '@monocdk-experiment/assert/jest';
+import {
+  App, Stack,
+  aws_codecommit as codecommit,
+  aws_codepipeline as cpipeline,
+  aws_chatbot as chatbot,
+} from 'monocdk';
+import { Pipeline, CodeCommitRepo, SlackNotification } from '../../lib';
+
+describe('slack notifications', () => {
+  test('failure notification via slack', () => {
+    // GIVEN
+    const stack = new Stack(new App(), 'TestStack');
+    const slackChannel = new chatbot.SlackChannelConfiguration(stack, 'notify', {
+      slackChannelConfigurationName: 'test-slack-config',
+      slackChannelId: 'test-channel-id',
+      slackWorkspaceId: 'test-workspace-id',
+    });
+    const pipe = new Pipeline(stack, 'Pipeline', {
+      repo: new CodeCommitRepo(new codecommit.Repository(stack, 'Repo1', { repositoryName: 'test' })),
+    });
+
+    // WHEN
+    pipe.notifyOnFailure(new SlackNotification({ channels: [slackChannel] }));
+
+    // THEN
+    expect(stack).toHaveResource('AWS::CodeStarNotifications::NotificationRule', {
+      DetailType: 'BASIC',
+      EventTypeIds: ['codepipeline-pipeline-action-execution-failed'],
+      Name: {
+        'Fn::Join': [
+          '',
+          [
+            {
+              Ref: 'PipelineBuildPipeline04C6628A',
+            },
+            '-failednotifications',
+          ],
+        ],
+      },
+      Resource: stack.resolve((pipe.node.findChild('BuildPipeline') as cpipeline.Pipeline).pipelineArn),
+      Targets: [
+        {
+          TargetAddress: stack.resolve(slackChannel.slackChannelConfigurationArn),
+          TargetType: 'AWSChatbotSlack',
+        },
+      ],
+    });
+  });
+});

--- a/test/pipeline-notifications/slack.test.ts
+++ b/test/pipeline-notifications/slack.test.ts
@@ -2,7 +2,6 @@ import '@monocdk-experiment/assert/jest';
 import {
   App, Stack,
   aws_codecommit as codecommit,
-  aws_codepipeline as cpipeline,
   aws_chatbot as chatbot,
 } from 'monocdk';
 import { Pipeline, CodeCommitRepo, SlackNotification } from '../../lib';
@@ -38,10 +37,50 @@ describe('slack notifications', () => {
           ],
         ],
       },
-      Resource: stack.resolve((pipe.node.findChild('BuildPipeline') as cpipeline.Pipeline).pipelineArn),
+      Resource: stack.resolve(pipe.pipeline.pipelineArn),
       Targets: [
         {
           TargetAddress: stack.resolve(slackChannel.slackChannelConfigurationArn),
+          TargetType: 'AWSChatbotSlack',
+        },
+      ],
+    });
+  });
+
+  test('multiple notifications', () => {
+    // GIVEN
+    const stack = new Stack(new App(), 'TestStack');
+    const slackChannel1 = new chatbot.SlackChannelConfiguration(stack, 'slack1', {
+      slackChannelConfigurationName: 'test-slack-config-1',
+      slackChannelId: 'test-channel-id-1',
+      slackWorkspaceId: 'test-workspace-id-1',
+    });
+    const slackChannel2 = new chatbot.SlackChannelConfiguration(stack, 'slack2', {
+      slackChannelConfigurationName: 'test-slack-config-2',
+      slackChannelId: 'test-channel-id-2',
+      slackWorkspaceId: 'test-workspace-id-2',
+    });
+    const pipe = new Pipeline(stack, 'Pipeline', {
+      repo: new CodeCommitRepo(new codecommit.Repository(stack, 'Repo1', { repositoryName: 'test' })),
+    });
+
+    // WHEN
+    pipe.notifyOnFailure(new SlackNotification({ channels: [slackChannel1] }));
+    pipe.notifyOnFailure(new SlackNotification({ channels: [slackChannel2] }));
+
+    // THEN
+    expect(stack).toHaveResource('AWS::CodeStarNotifications::NotificationRule', {
+      Targets: [
+        {
+          TargetAddress: stack.resolve(slackChannel1.slackChannelConfigurationArn),
+          TargetType: 'AWSChatbotSlack',
+        },
+      ],
+    });
+    expect(stack).toHaveResource('AWS::CodeStarNotifications::NotificationRule', {
+      Targets: [
+        {
+          TargetAddress: stack.resolve(slackChannel2.slackChannelConfigurationArn),
           TargetType: 'AWSChatbotSlack',
         },
       ],

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import { expect as cdk_expect, haveResource, haveResourceLike, SynthUtils, ABSENT } from '@monocdk-experiment/assert';
 import {
   App, Construct, Stack,
-  aws_chatbot as chatbot,
   aws_codebuild as codebuild,
   aws_codecommit as codecommit,
   aws_codepipeline as cpipeline,
@@ -10,7 +9,6 @@ import {
 } from 'monocdk';
 import * as delivlib from '../lib';
 import { determineRunOrder } from '../lib/util';
-
 
 test('pipelineName can be used to set a physical name for the pipeline', async () => {
   const stack = new Stack(new App(), 'TestStack');
@@ -316,63 +314,6 @@ test('CodeBuild Project name is left undefined when neither buildProjectName nor
   // THEN
   cdk_expect(stack).to(haveResourceLike('AWS::CodeBuild::Project', {
     Name: ABSENT,
-  }));
-});
-
-test('failure notification via slack is not present when not specified', () => {
-  // GIVEN
-  const stack = new Stack(new App(), 'TestStack');
-
-  // WHEN
-  new delivlib.Pipeline(stack, 'Pipeline1', {
-    repo: new delivlib.CodeCommitRepo(new codecommit.Repository(stack, 'Repo1', { repositoryName: 'test' })),
-  });
-  new delivlib.Pipeline(stack, 'Pipeline2', {
-    repo: new delivlib.CodeCommitRepo(new codecommit.Repository(stack, 'Repo2', { repositoryName: 'test' })),
-    failureNotifySlack: [],
-  });
-
-  // THEN
-  cdk_expect(stack).notTo(haveResource('AWS::CodeStarNotifications::NotificationRule'));
-});
-
-test('failure notification via slack', () => {
-  // GIVEN
-  const stack = new Stack(new App(), 'TestStack');
-  const slackChannel = new chatbot.SlackChannelConfiguration(stack, 'notify', {
-    slackChannelConfigurationName: 'test-slack-config',
-    slackChannelId: 'test-channel-id',
-    slackWorkspaceId: 'test-workspace-id',
-  });
-
-  // WHEN
-  const pipe = new delivlib.Pipeline(stack, 'Pipeline', {
-    repo: createTestRepo(stack),
-    failureNotifySlack: [slackChannel],
-  });
-
-  // THEN
-  cdk_expect(stack).to(haveResource('AWS::CodeStarNotifications::NotificationRule', {
-    DetailType: 'BASIC',
-    EventTypeIds: ['codepipeline-pipeline-action-execution-failed'],
-    Name: {
-      'Fn::Join': [
-        '',
-        [
-          {
-            Ref: 'PipelineBuildPipeline04C6628A',
-          },
-          '-failednotifications',
-        ],
-      ],
-    },
-    Resource: stack.resolve((pipe.node.findChild('BuildPipeline') as cpipeline.Pipeline).pipelineArn),
-    Targets: [
-      {
-        TargetAddress: stack.resolve(slackChannel.slackChannelConfigurationArn),
-        TargetType: 'AWSChatbotSlack',
-      },
-    ],
   }));
 });
 


### PR DESCRIPTION
The pipeline notifications is now switched to use a bind pattern
with an enum-like class for better APIs.

This makes the API extensible with the ability for users to write
their own if they wish. It also makes the interface cleaner and
reduces property fragmentation on `PipelineProps` for the same
feature, i.e., failure notifications.

BREAKING CHANGES: The property `failureNotifySlack` has been
removed and replaced by `notifyOnFailure()` API.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
