### PR TITLE
chore: make Nuget and PyPI publishing respect the FOR_REAL variable

### DIFF
--- a/lib/change-controller.ts
+++ b/lib/change-controller.ts
@@ -84,6 +84,7 @@ export class ChangeController extends Construct {
           '*.ts',
           'tsconfig.json',
           'yarn.lock',
+          'node_modules/.yarn-integrity',
         ],
       }),
       runtime: lambda.Runtime.NODEJS_10_X,

--- a/lib/publishing/nuget/publish.sh
+++ b/lib/publishing/nuget/publish.sh
@@ -4,6 +4,17 @@ set -eu # we don't want "pipefail" to implement idempotency
 echo "Installing required CLI tools: jq, openssl..."
 yum install -y jq openssl
 
+if [[ "${FOR_REAL:-}" == "true" ]]; then
+    dotnet=dotnet
+else
+    echo "==========================================="
+    echo "            🏜️ DRY-RUN MODE 🏜️"
+    echo
+    echo "Set FOR_REAL=true to do actual publishing!"
+    echo "==========================================="
+    dotnet="echo dotnet"
+fi
+
 if [ -n "${CODE_SIGNING_SECRET_ID:-}" ]; then
     declare -a CLEANUP=()
     function cleanup() {

--- a/lib/publishing/nuget/publish.sh
+++ b/lib/publishing/nuget/publish.sh
@@ -80,11 +80,11 @@ for NUGET_PACKAGE_PATH in $(find dotnet -name *.nupkg -not -iname *.symbols.nupk
 
         if [ -f "${NUGET_PACKAGE_BASE}.symbols.nupkg" ]; then
             # Legacy mode - there's a .symbols.nupkg file that can't go to the NuGet symbols server
-            dotnet nuget push $NUGET_PACKAGE_NAME -k $NUGET_API_KEY -s $NUGET_SOURCE -ss $NUGET_SYMBOL_SOURCE | tee ${log}
+            $dotnet nuget push $NUGET_PACKAGE_NAME -k $NUGET_API_KEY -s $NUGET_SOURCE -ss $NUGET_SYMBOL_SOURCE | tee ${log}
         else
             [ -f "${NUGET_PACKAGE_BASE}.snupkg" ] || echo "⚠️ No symbols package was found!"
             # The .snupkg will be published at the same time as the .nupkg if both are in the current folder (which is the case)
-            dotnet nuget push $NUGET_PACKAGE_NAME -k $NUGET_API_KEY -s $NUGET_SOURCE | tee ${log}
+            $dotnet nuget push $NUGET_PACKAGE_NAME -k $NUGET_API_KEY -s $NUGET_SOURCE | tee ${log}
         fi
     )
 

--- a/lib/publishing/pypi/publish.sh
+++ b/lib/publishing/pypi/publish.sh
@@ -8,4 +8,14 @@ export TWINE_PASSWORD=$(python -c "import json; print(json.loads('''${credential
 
 pip install twine
 
-twine upload --skip-existing python/**
+if [[ "${FOR_REAL:-}" == "true" ]]; then
+  twine upload --skip-existing python/**
+else
+  echo "==========================================="
+  echo "            🏜️ DRY-RUN MODE 🏜️"
+  echo
+  echo "Skipping the actual publishing step."
+  echo
+  echo "Set FOR_REAL=true to do it!"
+  echo "==========================================="
+fi

--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -350,7 +350,7 @@ export abstract class ShellPlatform {
    */
   public static get LinuxUbuntu(): ShellPlatform {
     // Cannot be static member because of initialization order
-    return new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_BASE);
+    return new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_4_0);
   }
 
   /**
@@ -358,7 +358,7 @@ export abstract class ShellPlatform {
    */
   public static get Windows(): ShellPlatform {
     // Cannot be static member because of initialization order
-    return new WindowsPlatform(cbuild.WindowsBuildImage.WIN_SERVER_CORE_2016_BASE);
+    return new WindowsPlatform(cbuild.WindowsBuildImage.WIN_SERVER_CORE_2019_BASE);
   }
 
   constructor(public readonly buildImage: cbuild.IBuildImage) {

--- a/test/canary.test.ts
+++ b/test/canary.test.ts
@@ -58,7 +58,7 @@ test('correctly creates canary', () => {
     },
     Environment: {
       ComputeType: 'BUILD_GENERAL1_MEDIUM',
-      Image: 'aws/codebuild/ubuntu-base:14.04',
+      Image: 'aws/codebuild/standard:4.0',
       PrivilegedMode: false,
       Type: 'LINUX_CONTAINER',
       EnvironmentVariables: [

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -4050,7 +4050,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: cdk-hnb659fds-assets-712950704752-us-east-1
-        S3Key: eed5453c0e8c5fded25ae0d7cfebab9fcfbd10abe59f7b6c15ff8f8b8018dcc9.zip
+        S3Key: 3dfb64a1f0ebffc81c711087c9ef73c6b9b1487b86611117e2081858feac0599.zip
       Handler: index.handler
       Role:
         Fn::GetAtt:

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -1596,7 +1596,7 @@ Resources:
           - Name: SCRIPT_S3_KEY
             Type: PLAINTEXT
             Value: 3d34b07ba871989d030649c646b3096ba7c78ca531897bcdb0670774d2f9d3e4.zip
-        Image: aws/codebuild/ubuntu-base:14.04
+        Image: aws/codebuild/standard:4.0
         PrivilegedMode: false
         Type: LINUX_CONTAINER
       ServiceRole:
@@ -1796,9 +1796,9 @@ Resources:
           - Name: SCRIPT_S3_KEY
             Type: PLAINTEXT
             Value: 36b33307c18c06726950e481637d4439c34e56a89ae6e2f1725e2718095e0985.zip
-        Image: aws/codebuild/windows-base:1.0
+        Image: aws/codebuild/windows-base:2019-1.0
         PrivilegedMode: false
-        Type: WINDOWS_CONTAINER
+        Type: WINDOWS_SERVER_2019_CONTAINER
       ServiceRole:
         Fn::GetAtt:
           - CodeCommitPipelineHelloWindowsRole769C073E
@@ -2004,7 +2004,7 @@ Resources:
             Type: PLAINTEXT
             Value:
               Ref: AssumeMe924099BB
-        Image: aws/codebuild/ubuntu-base:14.04
+        Image: aws/codebuild/standard:4.0
         PrivilegedMode: false
         Type: LINUX_CONTAINER
       ServiceRole:
@@ -2217,7 +2217,7 @@ Resources:
           - Name: SCRIPT_S3_KEY
             Type: PLAINTEXT
             Value: 3d34b07ba871989d030649c646b3096ba7c78ca531897bcdb0670774d2f9d3e4.zip
-        Image: aws/codebuild/ubuntu-base:14.04
+        Image: aws/codebuild/standard:4.0
         PrivilegedMode: false
         Type: LINUX_CONTAINER
       ServiceRole:
@@ -2379,7 +2379,7 @@ Resources:
           - Name: IS_CANARY
             Type: PLAINTEXT
             Value: "true"
-        Image: aws/codebuild/ubuntu-base:14.04
+        Image: aws/codebuild/standard:4.0
         PrivilegedMode: false
         Type: LINUX_CONTAINER
       ServiceRole:
@@ -2809,7 +2809,7 @@ Resources:
             Value: cdk-hnb659fds-assets-712950704752-us-east-1
           - Name: SCRIPT_S3_KEY
             Type: PLAINTEXT
-            Value: 18b64c4ff8c34f9925c226eb6cd9693b6d9b738290d88ed58e02da3d1d6fb927.zip
+            Value: c329cbf450eec2f7a537c1d2abb7b31f4370ef5b44bcf770f68e3b251e89b754.zip
           - Name: FOR_REAL
             Type: PLAINTEXT
             Value: "true"
@@ -3639,7 +3639,7 @@ Resources:
             Value: cdk-hnb659fds-assets-712950704752-us-east-1
           - Name: SCRIPT_S3_KEY
             Type: PLAINTEXT
-            Value: dc8eddab035b83a69e3f916300dc1f93dc508e78e729182de9f019cc8ffd7e3a.zip
+            Value: ce59f620887cda617e5a0b25e86cc026b339d2976b51830b2048fde6567507ca.zip
           - Name: FOR_REAL
             Type: PLAINTEXT
             Value: "true"
@@ -4050,7 +4050,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: cdk-hnb659fds-assets-712950704752-us-east-1
-        S3Key: 754b192f50fcd7e07ff2db430184f49d64a5b0c2e169db7cf705da7a05f80a0e.zip
+        S3Key: cc95c9cfd7eb7171bf3834df972a36ea35263a72715c1a6db9c61c1c864fb838.zip
       Handler: index.handler
       Role:
         Fn::GetAtt:

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -2809,7 +2809,7 @@ Resources:
             Value: cdk-hnb659fds-assets-712950704752-us-east-1
           - Name: SCRIPT_S3_KEY
             Type: PLAINTEXT
-            Value: c329cbf450eec2f7a537c1d2abb7b31f4370ef5b44bcf770f68e3b251e89b754.zip
+            Value: 0d799d16dbb6d580397dd6f5ba4c66ca43f7c699d1c2b4319e7135e68c62a8ce.zip
           - Name: FOR_REAL
             Type: PLAINTEXT
             Value: "true"

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -4050,7 +4050,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: cdk-hnb659fds-assets-712950704752-us-east-1
-        S3Key: cc95c9cfd7eb7171bf3834df972a36ea35263a72715c1a6db9c61c1c864fb838.zip
+        S3Key: eed5453c0e8c5fded25ae0d7cfebab9fcfbd10abe59f7b6c15ff8f8b8018dcc9.zip
       Handler: index.handler
       Role:
         Fn::GetAtt:


### PR DESCRIPTION
As part of investigating how to test publishing of V2, I discovered that neither
the Nuget or PyPI publishing scripts appear to handle the FOR_REAL env variable
that is respected by the other publishing steps. Copying the patterns from the
other publishing steps so these steps can be tested/mocked as well.

Related changes:
* I had to update the CodeBuild images, as the existing ones were deprecated and couldn't be used to launch new projects.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
