### PR TITLE
feat: expose underlying codebuild projects

### DIFF
--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -66,10 +66,13 @@ export interface AutoBuildProps extends AutoBuildOptions {
 }
 
 export class AutoBuild extends Construct {
+
+  public readonly project: codebuild.Project;
+
   constructor(scope: Construct, id: string, props: AutoBuildProps) {
     super(scope, id);
 
-    const project = new codebuild.Project(this, 'Project', {
+    this.project = new codebuild.Project(this, 'Project', {
       projectName: props.projectName,
       source: props.repo.createBuildSource(this, true, { branch: props.branch }),
       environment: createBuildEnvironment(props.environment ?? {}),
@@ -87,7 +90,7 @@ export class AutoBuild extends Construct {
           semanticVersion: '1.3.0',
         },
         parameters: {
-          CodeBuildProjectName: project.projectName,
+          CodeBuildProjectName: this.project.projectName,
           DeletePreviousComments: (props.deletePreviousPublicLogsLinks ?? true).toString(),
           ...githubToken ? { GitHubOAuthToken: Token.asString(githubToken) } : undefined,
         },

--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -67,6 +67,9 @@ export interface AutoBuildProps extends AutoBuildOptions {
 
 export class AutoBuild extends Construct {
 
+  /**
+   * The underlying `CodeBuild` project.
+   */
   public readonly project: codebuild.Project;
 
   constructor(scope: Construct, id: string, props: AutoBuildProps) {

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -311,6 +311,8 @@ export class Pipeline extends Construct {
 
   /**
    * Add an action to run a shell script to the pipeline
+   *
+   * @return The Shellable and the Action added to the pipeline.
    */
   public addShellable(stageName: string, id: string, options: AddShellableOptions): {
     shellable: Shellable, action: cpipeline_actions.CodeBuildAction} {

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -221,7 +221,7 @@ export class Pipeline extends Construct {
   /**
    * The auto build project. undefined if 'autoBuild' is disabled for this pipeline.
    */
-  public readonly autoBuildProject?: cbuild.IProject;
+  public readonly autoBuildProject?: cbuild.Project;
 
   /*
    * The underlying CodePipeline Pipeline object that models this pipeline.

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -10,7 +10,6 @@ import {
   aws_sns as sns,
   aws_sns_subscriptions as sns_subs,
 } from 'monocdk';
-import { CodeBuildAction } from 'monocdk/lib/aws-codepipeline-actions';
 
 import { AutoBuild, AutoBuildOptions } from './auto-build';
 import { createBuildEnvironment } from './build-env';
@@ -313,7 +312,8 @@ export class Pipeline extends Construct {
   /**
    * Add an action to run a shell script to the pipeline
    */
-  public addShellable(stageName: string, id: string, options: AddShellableOptions): {shellable: Shellable, action: CodeBuildAction} {
+  public addShellable(stageName: string, id: string, options: AddShellableOptions): {
+    shellable: Shellable, action: cpipeline_actions.CodeBuildAction} {
     const stage = this.getOrCreateStage(stageName);
 
     const sh = new Shellable(this, id, options);
@@ -330,7 +330,7 @@ export class Pipeline extends Construct {
     return { shellable: sh, action };
   }
 
-  public addTest(id: string, props: ShellableProps): {shellable: Shellable, action: CodeBuildAction} {
+  public addTest(id: string, props: ShellableProps): {shellable: Shellable, action: cpipeline_actions.CodeBuildAction} {
     return this.addShellable(TEST_STAGE_NAME, id, {
       actionName: `Test${id}`,
       failureNotification: `Test ${id} failed`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-delivlib",
-  "version": "9.2.0",
+  "version": "9.3.1",
   "homepage": "https://github.com/awslabs/aws-delivlib",
   "description": "A fabulous library for defining continuous pipelines for building, testing and releasing code libraries.",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-delivlib",
-  "version": "9.3.1",
+  "version": "9.2.0",
   "homepage": "https://github.com/awslabs/aws-delivlib",
   "description": "A fabulous library for defining continuous pipelines for building, testing and releasing code libraries.",
   "main": "lib/index.js",

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -142,7 +142,7 @@ test('can add arbitrary shellables with different artifacts', () => {
   const action = pipeline.addShellable('Test', 'SecondStep', {
     scriptDirectory: __dirname,
     entrypoint: 'run-test.sh',
-  });
+  }).action;
 
   pipeline.addPublish(new Pub(stack, 'Pub'), { inputArtifact: action.actionProperties.outputs![0] });
 

--- a/test/test-stack.ts
+++ b/test/test-stack.ts
@@ -91,7 +91,7 @@ export class TestStack extends Stack {
           artifact2: 'output2',
         },
       }),
-    });
+    }).action;
     const shellableArtifacts = action.actionProperties.outputs;
 
     //


### PR DESCRIPTION
This PR exposes the underlying `CodeBuild` project created by:

- The `AutoBuild` construct
- The `Shellable` construct

We need this in order to grant various permissions to the project roles.

BREAKING CHANGE: `pipeline.addShellable` now returns the shellable in addition to the action. Use `.action` to retrieve the action 

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
