### PR TITLE
feat: AutoBuild as its own feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,18 @@ available:
 1. [Source](#source)
    - [CodeCommit](#codecommit)
    - [GitHub](#github)
-2. [Build](#build)
-3. [Tests](#tests)
-4. [Publish](#publish)
+1. [Pull Request Builds](#pull-request-builds)
+1. [Build](#build)
+1. [Tests](#tests)
+1. [Publish](#publish)
    - [npm.js](#npmjs)
    - [NuGet](#nuget)
    - [Maven Central](#maven-central)
    - [PyPi](#pypi)
    - [GitHub Releases](#github-releases)
    - [GitHub Pages](#github-pages)
-5. [Automatic Bumps and Pull Request Builds](#automatic-bumps-and-pull-request-builds)
-6. [Failure Notifications](#failure-notifications)
+1. [Automatic Bumps and Pull Request Builds](#automatic-bumps-and-pull-request-builds)
+1. [Failure Notifications](#failure-notifications)
 
 
 ## Installation
@@ -151,6 +152,34 @@ new delivlib.Pipeline(this, 'MyPipeline', {
   repo: // ...
   branch: 'dev',
 })
+```
+
+## Pull Request Builds
+
+Pull Request Builds can be used to validate if changes submitted via a pull request
+successfully build and pass tests. They are triggered automatically by Github or
+CodeCommit when pull requests are submitted or updated.
+
+Known in delivlib as AutoBuild, they can be enabled on the Pipeline and further
+configured -
+
+```ts
+new delivlib.Pipeline(this, 'MyPipeline', {
+  // ...
+  autoBuild: true,
+  autoBuildOptions: {
+    publicLogs: true,
+  },
+});
+```
+
+Delivlib also seprately exports the `AutoBuild` construct that can be used to configure
+AutoBuild on a project that doesn't have a pipeline associated.
+
+```ts
+new delivlib.AutoBuild(this, 'MyAutoBuild', {
+  repo: // ...
+});
 ```
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ new delivlib.Pipeline(this, 'MyPipeline', {
 ## Pull Request Builds
 
 Pull Request Builds can be used to validate if changes submitted via a pull request
-successfully build and pass tests. They are triggered automatically by Github or
+successfully build and pass tests. They are triggered automatically by GitHub or
 CodeCommit when pull requests are submitted or updated.
 
 Known in delivlib as AutoBuild, they can be enabled on the Pipeline and further
@@ -173,8 +173,9 @@ new delivlib.Pipeline(this, 'MyPipeline', {
 });
 ```
 
-Delivlib also seprately exports the `AutoBuild` construct that can be used to configure
-AutoBuild on a project that doesn't have a pipeline associated.
+Delivlib also separately exports the `AutoBuild` construct that can be used to configure
+AutoBuild on a project that doesn't have a pipeline associated, or for jobs that can be
+run outside of a pipeline.
 
 ```ts
 new delivlib.AutoBuild(this, 'MyAutoBuild', {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
+export * from './auto-build';
 export * from './canary';
 export * from './build-spec';
 export * from './code-signing';


### PR DESCRIPTION
Previously, AutoBuild was only available via the Pipeline construct.
This change exports the AutoBuild construct so it can be used without
needing to create a Pipeline.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
