### PR TITLE
fix(pipeline-notifications): deployment fails to replace codestar notifications resource

### DIFF
--- a/lib/pipeline-notifications/slack.ts
+++ b/lib/pipeline-notifications/slack.ts
@@ -54,8 +54,9 @@ export class SlackNotification implements IPipelineNotification {
     });
     const md5 = crypto.createHash('md5');
     md5.update(JSON.stringify(targets));
-    new starnotifs.CfnNotificationRule(options.pipeline, `PipelineNotificationSlack-${md5.digest('hex')}`, {
-      name: `${options.pipeline.pipeline.pipelineName}-failednotifications`,
+    const hash = md5.digest('hex');
+    new starnotifs.CfnNotificationRule(options.pipeline, `PipelineNotificationSlack-${hash}`, {
+      name: `${options.pipeline.pipeline.pipelineName}-${hash}`,
       detailType: this.props.detailLevel ?? SlackNotificationDetailLevel.BASIC,
       resource: options.pipeline.pipeline.pipelineArn,
       targets,

--- a/test/pipeline-notifications/slack.test.ts
+++ b/test/pipeline-notifications/slack.test.ts
@@ -33,7 +33,7 @@ describe('slack notifications', () => {
             {
               Ref: 'PipelineBuildPipeline04C6628A',
             },
-            '-failednotifications',
+            '-32d5299b65be459fedc4e0d1b0e7c617',
           ],
         ],
       },


### PR DESCRIPTION
The `Name` property of `AWS::CodestarNotifications::NotificationRule`
needs to be unique within the account and region.
If it is not unique, then resource replacement will fail.

Include the hash in the `Name` property so as to keep it unique.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
