### PR TITLE
fix(chime-notifier): synthesis fails when webhook url is a token

### DIFF
--- a/lib/chime-notifier/chime-notifier.ts
+++ b/lib/chime-notifier/chime-notifier.ts
@@ -65,7 +65,7 @@ export class ChimeNotifier extends Construct {
         resources: [props.pipeline.pipelineArn],
       }));
 
-      props.pipeline.onStateChange(`ChimeOnFailure-${JSON.stringify(props.webhookUrls)}`, {
+      props.pipeline.onStateChange(`${this.node.path}-ChimeNotifier`, {
         target: new events_targets.LambdaFunction(notifierLambda, {
           event: events.RuleTargetInput.fromObject({
             // Add parameters

--- a/test/chime-notifier.test.ts
+++ b/test/chime-notifier.test.ts
@@ -1,6 +1,6 @@
 import * as https from 'https';
 import {
-  App, Construct, Stack,
+  App, Construct, Lazy, Stack,
   aws_codepipeline as aws_codepipeline,
   aws_codepipeline_actions as aws_codepipeline_actions,
 } from 'monocdk';
@@ -107,6 +107,20 @@ test('can add to stack', () => {
   });
 
   // EXPECT: no error
+  expect(stack).toHaveResource('AWS::Lambda::Function');
+});
+
+test('webhook url can be a token', () => {
+  const stack = new Stack(new App(), 'TestStack');
+  const pipeline = new aws_codepipeline.Pipeline(stack, 'Pipe');
+  pipeline.addStage({ stageName: 'Source', actions: [new FakeSourceAction()] });
+  pipeline.addStage({ stageName: 'Build', actions: [new aws_codepipeline_actions.ManualApprovalAction({ actionName: 'Dummy' })] });
+
+  new ChimeNotifier(stack, 'Chime', {
+    pipeline,
+    webhookUrls: [Lazy.stringValue({ produce: () => 'https://go/' })],
+  });
+
   expect(stack).toHaveResource('AWS::Lambda::Function');
 });
 


### PR DESCRIPTION
The cause is that the webhook url gets added as an id to the construct.
Change the logic so that the chime notifier construct path is used to
make the id unique instead.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
