### PR TITLE
feat(auto-build): option to not publish build logs when build is successful

### DIFF
--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -34,7 +34,7 @@ export interface AutoBuildOptions {
    *
    * @see https://github.com/jlhood/github-codebuild-logs#app-parameters
    *
-   * @default false
+   * @default true
    */
   readonly publicLogsOnSuccess?: boolean;
 
@@ -104,7 +104,7 @@ export class AutoBuild extends Construct {
         parameters: {
           CodeBuildProjectName: this.project.projectName,
           DeletePreviousComments: (props.deletePreviousPublicLogsLinks ?? true).toString(),
-          CommentOnSuccess: (props.publicLogsOnSuccess ?? false).toString(),
+          CommentOnSuccess: (props.publicLogsOnSuccess ?? true).toString(),
           ...githubToken ? { GitHubOAuthToken: Token.asString(githubToken) } : undefined,
         },
       });

--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -30,6 +30,15 @@ export interface AutoBuildOptions {
   readonly publicLogs?: boolean;
 
   /**
+   * Whether to publish a link to build logs when build is successful.
+   *
+   * @see https://github.com/jlhood/github-codebuild-logs#app-parameters
+   *
+   * @default false
+   */
+  readonly publicLogsOnSuccess?: boolean;
+
+  /**
    * Whether to delete previously published links to build logs
    * before posting a new one.
    *
@@ -90,11 +99,12 @@ export class AutoBuild extends Construct {
       new serverless.CfnApplication(this, 'GitHubCodeBuildLogsSAR', {
         location: {
           applicationId: 'arn:aws:serverlessrepo:us-east-1:277187709615:applications/github-codebuild-logs',
-          semanticVersion: '1.3.0',
+          semanticVersion: '1.4.0',
         },
         parameters: {
           CodeBuildProjectName: this.project.projectName,
           DeletePreviousComments: (props.deletePreviousPublicLogsLinks ?? true).toString(),
+          CommentOnSuccess: (props.publicLogsOnSuccess ?? false).toString(),
           ...githubToken ? { GitHubOAuthToken: Token.asString(githubToken) } : undefined,
         },
       });

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -3939,11 +3939,12 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:277187709615:applications/github-codebuild-logs
-        SemanticVersion: 1.3.0
+        SemanticVersion: 1.4.0
       Parameters:
         CodeBuildProjectName:
           Ref: CodeCommitPipelineAutoBuildProject5D212EE9
         DeletePreviousComments: "true"
+        CommentOnSuccess: "false"
         GitHubOAuthToken: "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW:SecretString:::}}"
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBuild/GitHubCodeBuildLogsSAR

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -3944,7 +3944,7 @@ Resources:
         CodeBuildProjectName:
           Ref: CodeCommitPipelineAutoBuildProject5D212EE9
         DeletePreviousComments: "true"
-        CommentOnSuccess: "false"
+        CommentOnSuccess: "true"
         GitHubOAuthToken: "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW:SecretString:::}}"
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/AutoBuild/GitHubCodeBuildLogsSAR

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -213,7 +213,7 @@ test('autoBuild() can be used to add automatic builds to the pipeline', () => {
   cdk_expect(stack).notTo(haveResource('AWS::Serverless::Application', {
     Location: {
       ApplicationId: 'arn:aws:serverlessrepo:us-east-1:277187709615:applications/github-codebuild-logs',
-      SemanticVersion: '1.3.0',
+      SemanticVersion: '1.4.0',
     },
   }));
 });
@@ -235,7 +235,14 @@ test('autoBuild() can be configured to publish logs publically', () => {
   cdk_expect(stack).to(haveResource('AWS::Serverless::Application', {
     Location: {
       ApplicationId: 'arn:aws:serverlessrepo:us-east-1:277187709615:applications/github-codebuild-logs',
-      SemanticVersion: '1.3.0',
+      SemanticVersion: '1.4.0',
+    },
+    Parameters: {
+      CodeBuildProjectName: {
+        Ref: 'PipelineAutoBuildProjectB97B4446',
+      },
+      DeletePreviousComments: 'true',
+      CommentOnSuccess: 'false',
     },
   }));
 });

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -242,7 +242,7 @@ test('autoBuild() can be configured to publish logs publically', () => {
         Ref: 'PipelineAutoBuildProjectB97B4446',
       },
       DeletePreviousComments: 'true',
-      CommentOnSuccess: 'false',
+      CommentOnSuccess: 'true',
     },
   }));
 });


### PR DESCRIPTION
Removes noise in PR comments.

I bet those logs are hardly ever checked.

See https://github.com/jlhood/github-codebuild-logs/pull/29


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
