### PR TITLE
fix(ecr-mirror): sync job fails when using MirrorSource.fromDirectory()

### DIFF
--- a/test/registry-sync/mirror-source.test.ts
+++ b/test/registry-sync/mirror-source.test.ts
@@ -1,7 +1,9 @@
 import '@monocdk-experiment/assert/jest';
 import * as path from 'path';
+import { arrayWith } from '@monocdk-experiment/assert';
 import {
   Stack,
+  aws_codebuild as codebuild,
 } from 'monocdk';
 import { MirrorSource } from '../../lib/registry-sync';
 
@@ -22,6 +24,10 @@ describe('RegistryImageSource', () => {
       // THEN
       expect(result.repositoryName).toEqual('jsii/superchain');
       expect(result.tag).toEqual('latest');
+      expect(result.commands).toEqual([
+        'docker pull jsii/superchain:latest',
+        'docker tag jsii/superchain:latest myregistry/jsii/superchain:latest',
+      ]);
     });
 
     test('explicit tag', () => {
@@ -39,6 +45,10 @@ describe('RegistryImageSource', () => {
       // THEN
       expect(result.repositoryName).toEqual('jsii/superchain');
       expect(result.tag).toEqual('mytag');
+      expect(result.commands).toEqual([
+        'docker pull jsii/superchain:mytag',
+        'docker tag jsii/superchain:mytag myregistry/jsii/superchain:mytag',
+      ]);
     });
 
     test('official image', () => {
@@ -55,6 +65,10 @@ describe('RegistryImageSource', () => {
 
       // THEN
       expect(result.repositoryName).toEqual('library/superchain');
+      expect(result.commands).toEqual([
+        'docker pull library/superchain:latest',
+        'docker tag library/superchain:latest myregistry/library/superchain:latest',
+      ]);
     });
 
     test('fails if image includes tag', () => {
@@ -78,6 +92,12 @@ describe('RegistryImageSource', () => {
       // THEN
       expect(result.repositoryName).toEqual('myrepository');
       expect(result.tag).toEqual('latest');
+      const cmds = result.commands;
+      expect(cmds.shift()).toMatch(/aws s3 cp s3:.* myrepository.zip/);
+      expect(cmds).toEqual([
+        'unzip myrepository.zip -d myrepository',
+        'docker build --pull -t myregistry/myrepository:latest myrepository',
+      ]);
     });
 
     test('explicit tag', () => {
@@ -95,6 +115,63 @@ describe('RegistryImageSource', () => {
       // THEN
       expect(result.repositoryName).toEqual('myrepository');
       expect(result.tag).toEqual('mytag');
+      expect(result.commands[2]).toEqual('docker build --pull -t myregistry/myrepository:mytag myrepository');
+    });
+
+    test('syncJob is given permission to s3 asset', () => {
+      // GIVEN
+      const stack = new Stack();
+      const ecrRegistry = 'myregistry';
+      const source = MirrorSource.fromDirectory(path.join(__dirname, 'docker-asset'), 'myrepository');
+      const syncJob = new codebuild.Project(stack, 'SyncJob', {
+        buildSpec: codebuild.BuildSpec.fromObject({}),
+      });
+
+      // WHEN
+      source.bind({
+        scope: stack,
+        ecrRegistry,
+        syncJob,
+      });
+
+      // THEN
+      expect(stack).toHaveResourceLike('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: arrayWith({
+            Action: [
+              's3:GetObject*',
+              's3:GetBucket*',
+              's3:List*',
+            ],
+            Effect: 'Allow',
+            Resource: [
+              {
+                'Fn::Join': [
+                  '',
+                  [
+                    'arn:', { Ref: 'AWS::Partition' }, ':s3:::',
+                    {
+                      Ref: 'AssetParameterse8d9cb1c0103dbf504327aacfe6adaaaa0749014246bf11110b90ace9e5ee1c8S3BucketABAF9C0C',
+                    },
+                  ],
+                ],
+              },
+              {
+                'Fn::Join': [
+                  '',
+                  [
+                    'arn:', { Ref: 'AWS::Partition' }, ':s3:::',
+                    {
+                      Ref: 'AssetParameterse8d9cb1c0103dbf504327aacfe6adaaaa0749014246bf11110b90ace9e5ee1c8S3BucketABAF9C0C',
+                    },
+                    '/*',
+                  ],
+                ],
+              },
+            ],
+          }),
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
The CodeBuild sync job needs to have permissions to read the S3 bucket
where the mirror source places the source files.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
