### PR TITLE
chore(pull-request): remove the use of Omit chain

### DIFF
--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -18,7 +18,8 @@ import { ChangeController } from './change-controller';
 import { ChimeNotifier } from './chime-notifier';
 import { PipelineWatcher } from './pipeline-watcher';
 import * as publishing from './publishing';
-import { AutoBump, AutoMergeBack, AutoMergeBackProps, AutoBumpProps } from './pull-request';
+import { AutoBump, AutoMergeBack, AutoBumpProps } from './pull-request';
+import { AutoMergeBackOptions } from './pull-request/merge-back';
 import { IRepo, WritableGitHubRepo } from './repo';
 import { Shellable, ShellableProps } from './shellable';
 import { determineRunOrder } from './util';
@@ -168,34 +169,6 @@ export interface PipelineNotificationBindOptions {
 
 export interface IPipelineNotification {
   bind(pipeline: PipelineNotificationBindOptions): void;
-}
-
-export interface MergeBackStage {
-
-  /**
-   * Which stage should the merge back be part of. (Created if missing)
-   *
-   * @default 'MergeBack'
-   */
-  readonly name?: string
-
-  /**
-   * The name of the stage that the merge back stage should go after of. (Must exist)
-   */
-  readonly after: string;
-}
-
-/**
- * Options for configuring an auto merge-back for this pipeline.
- */
-export interface AutoMergeBackOptions extends Omit<AutoMergeBackProps, 'repo'> {
-
-  /**
-   * Specify stage options to create the merge back inside a stage of the pipeline.
-   *
-   * @default - The CodeBuild project will be created indepdent of any stage.
-   */
-  readonly stage?: MergeBackStage
 }
 
 /**

--- a/lib/pull-request/bump.ts
+++ b/lib/pull-request/bump.ts
@@ -1,15 +1,5 @@
 import * as cdk from 'monocdk';
-import { AutoPullRequest, AutoPullRequestProps } from './pr';
-
-/**
- *
- * We want to expose most of the AutoPullRequestOptions, but not all:
- *
- *  - commands: In this context, it is provided by the 'bumpCommand' property, which is clearer to reason about and provide a sane default.
- *  - condition: We choose not to expose at the moment and use a hardcoded one.
- *  - head: We want to provide a default value for the head branch name.
- */
-type Omitted = Omit<AutoPullRequestProps, 'commands' | 'condition' | 'head'>;
+import { AutoPullRequest, AutoPullRequestOptions } from './pr';
 
 /**
  * Properties for configuring the head branch of the bump PR.
@@ -34,7 +24,7 @@ export interface AutoBumpHead {
 /**
  * Options for configuring an Auto Bump project.
  */
-export interface AutoBumpProps extends Omitted {
+export interface AutoBumpProps extends AutoPullRequestOptions {
 
   /**
    * The command to execute in order to bump the repo.

--- a/lib/pull-request/pr.ts
+++ b/lib/pull-request/pr.ts
@@ -12,17 +12,12 @@ import { WritableGitHubRepo } from '../repo';
 /**
  * Properties for creating a Pull Request Job.
  */
-export interface AutoPullRequestProps {
+export interface AutoPullRequestOptions {
 
   /**
    * The repository to create a PR in.
    */
   repo: WritableGitHubRepo;
-
-  /**
-   * The head branch of the PR.
-   */
-  head: Head;
 
   /**
    * The base branch of the PR.
@@ -71,27 +66,6 @@ export interface AutoPullRequestProps {
   build?: BuildEnvironmentProps;
 
   /**
-   * A set of commands to run against the head branch.
-   * Useful for things like version bumps or any auto-generated commits.
-   *
-   * Note that you cannot use export keys in these commands (See `exports` property)
-   *
-   * @default - no commands.
-   */
-  commands?: string[];
-
-  /**
-   * The exit code of this command determines whether or not to proceed with the
-   * PR creation. If configured, this command is the first one to run, and if it fails, all
-   * other commands will be skipped.
-   *
-   * This command is the first to execute, and should not assume any pre-existing state.
-   *
-   * @default - no condition
-   */
-  condition?: string;
-
-  /**
    * Git clone depth.
    *
    * @default 0 (clones the entire repository revisions)
@@ -134,6 +108,34 @@ export interface AutoPullRequestProps {
    */
   scheduleExpression?: string;
 
+}
+
+export interface AutoPullRequestProps extends AutoPullRequestOptions {
+  /**
+   * A set of commands to run against the head branch.
+   * Useful for things like version bumps or any auto-generated commits.
+   *
+   * Note that you cannot use export keys in these commands (See `exports` property)
+   *
+   * @default - no commands.
+   */
+  commands?: string[];
+
+  /**
+   * The head branch of the PR.
+   */
+  head: Head;
+
+  /**
+   * The exit code of this command determines whether or not to proceed with the
+   * PR creation. If configured, this command is the first one to run, and if it fails, all
+   * other commands will be skipped.
+   *
+   * This command is the first to execute, and should not assume any pre-existing state.
+   *
+   * @default - no condition
+   */
+  condition?: string;
 }
 
 /**


### PR DESCRIPTION
We've introduced an Omit chain in the interfaces around auto pull 
requests. Instead, use more traditional 'Props inherits Options'
approach to make the code more readable.

----

#### Additional Testing

Applied this with change on `cdk-ops` using `yarn link` and noted that there were no visible changes that seemed to indicate a diff here. 

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
