### PR TITLE
fix: remove repo as required property of AutoMergeBackOptions

### DIFF
--- a/lib/pull-request/bump.ts
+++ b/lib/pull-request/bump.ts
@@ -1,4 +1,5 @@
 import * as cdk from 'monocdk';
+import { WritableGitHubRepo } from '../repo';
 import { AutoPullRequest, AutoPullRequestOptions } from './pr';
 
 /**
@@ -25,6 +26,10 @@ export interface AutoBumpHead {
  * Options for configuring an Auto Bump project.
  */
 export interface AutoBumpProps extends AutoPullRequestOptions {
+  /**
+   * The repository to create a PR in.
+   */
+  repo: WritableGitHubRepo;
 
   /**
    * The command to execute in order to bump the repo.

--- a/lib/pull-request/merge-back.ts
+++ b/lib/pull-request/merge-back.ts
@@ -39,9 +39,8 @@ export interface MergeBackStage {
 
 /**
  * AutoMergeBackOptions and AutoMergeBackProps both share all of these options,
- * but AutoMergeBackProps can't extend AutoMergeBackOptions, as the 'stage' prop of AutoMergeBackOptions
- * is only applicable to the AutoMergeBackOptions interface. This interface instead captures all of the
- * common props between the two.
+ * but AutoMergeBackProps can't extend AutoMergeBackOptions; the latter has a 'stage' prop the former doesn't have.
+ * This interface instead captures all of the common props between the two.
  */
 interface CommonMergeOptions extends pr.AutoPullRequestOptions {
   /**
@@ -89,7 +88,7 @@ interface CommonMergeOptions extends pr.AutoPullRequestOptions {
   condition?: string;
 }
 
-export interface AutoMergeBackOptions extends pr.AutoPullRequestOptions, CommonMergeOptions {
+export interface AutoMergeBackOptions extends CommonMergeOptions {
   /**
    * Specify stage options to create the merge back inside a stage of the pipeline.
    *
@@ -98,7 +97,7 @@ export interface AutoMergeBackOptions extends pr.AutoPullRequestOptions, CommonM
   readonly stage?: MergeBackStage
 }
 
-export interface AutoMergeBackProps extends pr.AutoPullRequestOptions, CommonMergeOptions {
+export interface AutoMergeBackProps extends CommonMergeOptions {
   /**
    * The repository to bump.
    */

--- a/lib/pull-request/merge-back.ts
+++ b/lib/pull-request/merge-back.ts
@@ -37,7 +37,13 @@ export interface MergeBackStage {
   readonly after: string;
 }
 
-export interface AutoMergeBackOptions extends pr.AutoPullRequestOptions {
+/**
+ * AutoMergeBackOptions and AutoMergeBackProps both share all of these options,
+ * but AutoMergeBackProps can't extend AutoMergeBackOptions, as the 'stage' prop of AutoMergeBackOptions
+ * is only applicable to the AutoMergeBackOptions interface. This interface instead captures all of the
+ * common props between the two.
+ */
+interface CommonMergeOptions extends pr.AutoPullRequestOptions {
   /**
    * The command to determine the current version.
    *
@@ -81,7 +87,9 @@ export interface AutoMergeBackOptions extends pr.AutoPullRequestOptions {
    * @default - no condition
    */
   condition?: string;
+}
 
+export interface AutoMergeBackOptions extends pr.AutoPullRequestOptions, CommonMergeOptions {
   /**
    * Specify stage options to create the merge back inside a stage of the pipeline.
    *
@@ -90,7 +98,7 @@ export interface AutoMergeBackOptions extends pr.AutoPullRequestOptions {
   readonly stage?: MergeBackStage
 }
 
-export interface AutoMergeBackProps extends AutoMergeBackOptions {
+export interface AutoMergeBackProps extends pr.AutoPullRequestOptions, CommonMergeOptions {
   /**
    * The repository to bump.
    */

--- a/lib/pull-request/pr.ts
+++ b/lib/pull-request/pr.ts
@@ -13,12 +13,6 @@ import { WritableGitHubRepo } from '../repo';
  * Properties for creating a Pull Request Job.
  */
 export interface AutoPullRequestOptions {
-
-  /**
-   * The repository to create a PR in.
-   */
-  repo: WritableGitHubRepo;
-
   /**
    * The base branch of the PR.
    *
@@ -111,6 +105,11 @@ export interface AutoPullRequestOptions {
 }
 
 export interface AutoPullRequestProps extends AutoPullRequestOptions {
+  /**
+   * The repository to create a PR in.
+   */
+  repo: WritableGitHubRepo;
+
   /**
    * A set of commands to run against the head branch.
    * Useful for things like version bumps or any auto-generated commits.


### PR DESCRIPTION
The refactoring in #671 unintentionally changed the signature of
AutoMergeBackOptions to make `repo` a required property, and also
added the `stage` property to AutoMergeBackProperties. This change
reverts both back to the pre-refactor state.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
