### PR TITLE
chore(bump): refactor AutoMergeBackOptions

### DIFF
--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -19,7 +19,7 @@ import { ChimeNotifier } from './chime-notifier';
 import { PipelineWatcher } from './pipeline-watcher';
 import * as publishing from './publishing';
 import { AutoBump, AutoMergeBack, AutoBumpProps } from './pull-request';
-import { AutoMergeBackOptions } from './pull-request/merge-back';
+import { AutoMergeBackOptionsWithStage } from './pull-request/merge-back';
 import { IRepo, WritableGitHubRepo } from './repo';
 import { Shellable, ShellableProps } from './shellable';
 import { determineRunOrder } from './util';
@@ -415,9 +415,9 @@ export class Pipeline extends Construct {
 
   /**
    * Enables automatic merge backs for the source repo.
-   * @param options Options for auto bump (see AutoMergeBackOptions for description of defaults)
+   * @param options Options for auto bump (see AutoMergeBackOptionsWithStage for description of defaults)
    */
-  public autoMergeBack(options?: AutoMergeBackOptions) {
+  public autoMergeBack(options?: AutoMergeBackOptionsWithStage) {
     if (!WritableGitHubRepo.isWritableGitHubRepo(this.repo)) {
       throw new Error('"repo" must be a WritableGitHubRepo in order to enable auto-merge-back');
     }

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -19,7 +19,7 @@ import { ChimeNotifier } from './chime-notifier';
 import { PipelineWatcher } from './pipeline-watcher';
 import * as publishing from './publishing';
 import { AutoBump, AutoMergeBack, AutoBumpProps } from './pull-request';
-import { AutoMergeBackOptionsWithStage } from './pull-request/merge-back';
+import { AutoMergeBackPipelineOptions } from './pull-request/merge-back';
 import { IRepo, WritableGitHubRepo } from './repo';
 import { Shellable, ShellableProps } from './shellable';
 import { determineRunOrder } from './util';
@@ -415,9 +415,9 @@ export class Pipeline extends Construct {
 
   /**
    * Enables automatic merge backs for the source repo.
-   * @param options Options for auto bump (see AutoMergeBackOptionsWithStage for description of defaults)
+   * @param options Options for auto bump (see AutoMergeBackPipelineOptions for description of defaults)
    */
-  public autoMergeBack(options?: AutoMergeBackOptionsWithStage) {
+  public autoMergeBack(options?: AutoMergeBackPipelineOptions) {
     if (!WritableGitHubRepo.isWritableGitHubRepo(this.repo)) {
       throw new Error('"repo" must be a WritableGitHubRepo in order to enable auto-merge-back');
     }

--- a/lib/pull-request/merge-back.ts
+++ b/lib/pull-request/merge-back.ts
@@ -83,7 +83,7 @@ export interface AutoMergeBackOptions extends pr.AutoPullRequestOptions {
   condition?: string;
 }
 
-export interface AutoMergeBackOptionsWithStage extends AutoMergeBackOptions {
+export interface AutoMergeBackPipelineOptions extends AutoMergeBackOptions {
   /**
    * Specify stage options to create the merge back inside a stage of the pipeline.
    *

--- a/lib/pull-request/merge-back.ts
+++ b/lib/pull-request/merge-back.ts
@@ -37,12 +37,7 @@ export interface MergeBackStage {
   readonly after: string;
 }
 
-/**
- * AutoMergeBackOptions and AutoMergeBackProps both share all of these options,
- * but AutoMergeBackProps can't extend AutoMergeBackOptions; the latter has a 'stage' prop the former doesn't have.
- * This interface instead captures all of the common props between the two.
- */
-interface CommonMergeOptions extends pr.AutoPullRequestOptions {
+export interface AutoMergeBackOptions extends pr.AutoPullRequestOptions {
   /**
    * The command to determine the current version.
    *
@@ -88,7 +83,7 @@ interface CommonMergeOptions extends pr.AutoPullRequestOptions {
   condition?: string;
 }
 
-export interface AutoMergeBackOptions extends CommonMergeOptions {
+export interface AutoMergeBackOptionsWithStage extends AutoMergeBackOptions {
   /**
    * Specify stage options to create the merge back inside a stage of the pipeline.
    *
@@ -97,7 +92,7 @@ export interface AutoMergeBackOptions extends CommonMergeOptions {
   readonly stage?: MergeBackStage
 }
 
-export interface AutoMergeBackProps extends CommonMergeOptions {
+export interface AutoMergeBackProps extends AutoMergeBackOptions {
   /**
    * The repository to bump.
    */


### PR DESCRIPTION
As discussed in #684, refactoring the AutoMergeBack interfaces to have a more
standard hierarchy. This change removes 'stage' from AutoMergeBackOptions,
and creates a stage-specific AutoMergeBackPipelineOptions.

BREAKING CHANGE: the 'stage' prop of AutoMergeBackOptions has been moved to a
new AutoMergeBackPipelineOptions interface.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
