### PR TITLE
feat(pipeline): improved pipeline failure metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,11 +674,21 @@ To create an ssh deploy key for your repository:
 The `Pipeline` construct automatically creates the following metrics in CloudWatch
 for the configured pipelines. These are published under the namespace 'CDK/Delivlib'.
 
-- *PipelineActionFailures:* For every failed action in the pipeline, a '1' is
-  published to the metric, and for every successful action, sa '0' is published.
+- Execution Failures: The number of failures of the pipeline execution.
+  When a pipeline execution fails, a '1' is recorded and forevery success, a '0' is
+  recorded.
 
-  This metric has the following dimensions:
-  - *Pipeline*: The pipeline name in CodePipeline,
+  Metric Name: *Failures*
+  Dimensions:
+  - *Pipeline*: The pipeline name in CodePipeline.
+
+- Action Failures: The number of failures per action per pipeline. An execution
+  failure can be due to multiple actions failing.
+  For every action failure, a '1' is recorded and for every success, a '0' is recorded.
+
+  Metric Name: *Failures*
+  Dimensions:
+  - *Pipeline*: The pipeline name in CodePipeline.
   - *Action*: THe name of the action that succeeded or failed.
 
 ## Automatic Bumps and Pull Request Builds

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ available:
    - [PyPi](#pypi)
    - [GitHub Releases](#github-releases)
    - [GitHub Pages](#github-pages)
+1. [Metrics](#metrics)
 1. [Automatic Bumps and Pull Request Builds](#automatic-bumps-and-pull-request-builds)
 1. [Failure Notifications](#failure-notifications)
 1. [ECR Mirror](#ecr-mirror)
@@ -667,6 +668,18 @@ To create an ssh deploy key for your repository:
 1. Create an AWS Secrets Manager secret and paste the private key as plaintext
    (not key/value).
 1. Use the name of the AWS Secrets Manager secret in the `sshKeySecret` option.
+
+## Metrics
+
+The `Pipeline` construct automatically creates the following metrics in CloudWatch
+for the configured pipelines. These are published under the namespace 'CDK/Delivlib'.
+
+- *PipelineActionFailures:* For every failed action in the pipeline, a '1' is
+  published to the metric, and for every successful action, sa '0' is published.
+
+  This metric has the following dimensions:
+  - *Pipeline*: The pipeline name in CodePipeline,
+  - *Action*: THe name of the action that succeeded or failed.
 
 ## Automatic Bumps and Pull Request Builds
 

--- a/lib/pipeline-watcher/handler/watcher-handler.ts
+++ b/lib/pipeline-watcher/handler/watcher-handler.ts
@@ -15,11 +15,8 @@ const logger = {
 };
 
 /**
- * Lambda function for checking the stages of a CodePipeline and emitting log
- * entries with { failedCount = <no. of failed stages> } for async metric
- * aggregation via metric filters.
- *
- * It requires the pipeline's name be set as the 'PIPELINE_NAME' environment variable.
+ * Lambda function that reacts to an Amazon EventBridge event triggered by a 'CodePipeline Action Execution State Change'.
+ * The handler reads the event and sends off metrics to CloudWatch.
  */
 export async function handler(event: AWSLambda.EventBridgeEvent<'CodePipeline Action Execution State Change', CodePipelineActionStateChangeEvent>) {
   logger.log(`Received event: ${JSON.stringify(event)}`);

--- a/lib/pipeline-watcher/handler/watcher-handler.ts
+++ b/lib/pipeline-watcher/handler/watcher-handler.ts
@@ -2,7 +2,7 @@ import * as AWS from 'aws-sdk';
 
 // Partial type for the 'detail' section of an event from Amazon EventBridge for 'CodePipeline Action Execution State Change'
 // See https://docs.aws.amazon.com/eventbridge/latest/userguide/event-types.html#codepipeline-event-type
-interface CodePipelineActionStateChangeEvent {
+export interface CodePipelineActionStateChangeEvent {
   readonly pipeline: string;
   readonly action: string;
   readonly state: 'STARTED' | 'CANCELED' | 'FAILED' | 'SUCCEEDED';
@@ -10,7 +10,7 @@ interface CodePipelineActionStateChangeEvent {
 
 // export for tests
 export const cloudwatch = new AWS.CloudWatch();
-export const logger = {
+const logger = {
   log: (line: string) => process.stdout.write(line),
 };
 
@@ -39,7 +39,8 @@ export async function handler(event: AWSLambda.EventBridgeEvent<'CodePipeline Ac
   switch (state) {
     case 'FAILED': value = 1; break;
     case 'SUCCEEDED': value = 0; break;
-    default: throw new Error('Only FAILED and SUCCEEDED states are supported. Others must be filtered out prior to this function.');
+    default: throw new Error(`Unsupported state: ${state}. Only FAILED and SUCCEEDED states are supported. ` +
+    'Others must be filtered out prior to this function.');
   }
 
   logger.log(`Calling PutMetricData with payload: ${JSON.stringify(event)}`);

--- a/lib/pipeline-watcher/handler/watcher-handler.ts
+++ b/lib/pipeline-watcher/handler/watcher-handler.ts
@@ -1,12 +1,21 @@
 import * as AWS from 'aws-sdk';
 
-// Partial type for the 'detail' section of an event from Amazon EventBridge for 'CodePipeline Action Execution State Change'
+// Partial type for the 'detail' section of an event from Amazon EventBridge for 'CodePipeline Execution State Change'
 // See https://docs.aws.amazon.com/eventbridge/latest/userguide/event-types.html#codepipeline-event-type
-export interface CodePipelineActionStateChangeEvent {
+export interface ExecutionStateChangeEvent {
   readonly pipeline: string;
-  readonly action: string;
   readonly state: 'STARTED' | 'CANCELED' | 'FAILED' | 'SUCCEEDED';
 }
+
+// Partial type for the 'detail' section of an event from Amazon EventBridge for 'CodePipeline Action Execution State Change'
+// See https://docs.aws.amazon.com/eventbridge/latest/userguide/event-types.html#codepipeline-event-type
+export interface ActionStateChangeEvent extends ExecutionStateChangeEvent {
+  readonly action: string;
+}
+
+export type LambdaExecutionStateChangeEvent = AWSLambda.EventBridgeEvent<'CodePipeline Pipeline Execution State Change', ExecutionStateChangeEvent>;
+export type LambdaActionStateChangeEvent = AWSLambda.EventBridgeEvent<'CodePipeline Action Execution State Change', ActionStateChangeEvent>;
+export type EventType = LambdaExecutionStateChangeEvent | LambdaActionStateChangeEvent;
 
 // export for tests
 export const cloudwatch = new AWS.CloudWatch();
@@ -18,19 +27,19 @@ const logger = {
  * Lambda function that reacts to an Amazon EventBridge event triggered by a 'CodePipeline Action Execution State Change'.
  * The handler reads the event and sends off metrics to CloudWatch.
  */
-export async function handler(event: AWSLambda.EventBridgeEvent<'CodePipeline Action Execution State Change', CodePipelineActionStateChangeEvent>) {
+export async function handler(event: EventType) {
   logger.log(`Received event: ${JSON.stringify(event)}`);
 
-  const metricNamespace = process.env.METRIC_NAMESPACE;
-  const metricName = process.env.METRIC_NAME;
-  const pipelineName = event.detail.pipeline;
-  const action = event.detail.action;
-  const state = event.detail.state;
-  const time = new Date(event.time);
-
-  if (!metricNamespace || !metricName) {
-    throw new Error('Both METRIC_NAMESPACE and METRIC_NAME environment variables must be set.');
+  switch (event['detail-type']) {
+    case 'CodePipeline Pipeline Execution State Change': await handleExecutionChange(event); break;
+    case 'CodePipeline Action Execution State Change': await handleActionChange(event); break;
+    default: throw new Error(`Unhandled detail type ${event['detaill-type']}`);
   }
+}
+
+async function handleExecutionChange(event: LambdaExecutionStateChangeEvent) {
+  const pipelineName = event.detail.pipeline;
+  const state = event.detail.state;
 
   let value: number;
   switch (state) {
@@ -40,28 +49,57 @@ export async function handler(event: AWSLambda.EventBridgeEvent<'CodePipeline Ac
     'Others must be filtered out prior to this function.');
   }
 
-  logger.log(`Calling PutMetricData with payload: ${JSON.stringify(event)}`);
+  await putMetric(event, value, [
+    { Name: 'Pipeline', Value: pipelineName },
+  ]);
+
+  logger.log('Done');
+}
+
+
+async function handleActionChange(event: LambdaActionStateChangeEvent) {
+  const pipelineName = event.detail.pipeline;
+  const action = event.detail.action;
+  const state = event.detail.state;
+
+  let value: number;
+  switch (state) {
+    case 'FAILED': value = 1; break;
+    case 'SUCCEEDED': value = 0; break;
+    default: throw new Error(`Unsupported state: ${state}. Only FAILED and SUCCEEDED states are supported. ` +
+    'Others must be filtered out prior to this function.');
+  }
+
+  await putMetric(event, value, [
+    { Name: 'Pipeline', Value: pipelineName },
+    { Name: 'Action', Value: action },
+  ]);
+
+  logger.log('Done');
+}
+
+async function putMetric(event: EventType, value: number, dimensions: AWS.CloudWatch.Dimensions) {
+  const metricNamespace = process.env.METRIC_NAMESPACE;
+  const metricName = process.env.METRIC_NAME;
+  const time = new Date(event.time);
+
+  if (!metricNamespace || !metricName) {
+    throw new Error('Both METRIC_NAMESPACE and METRIC_NAME environment variables must be set.');
+  }
+
   const input: AWS.CloudWatch.PutMetricDataInput = {
     Namespace: metricNamespace,
     MetricData: [
       {
         MetricName: metricName,
         Value: value,
-        Dimensions: [
-          {
-            Name: 'Pipeline',
-            Value: pipelineName,
-          },
-          {
-            Name: 'Action',
-            Value: action,
-          },
-        ],
+        Dimensions: dimensions,
         Timestamp: time,
       },
     ],
   };
 
+  logger.log(`Calling PutMetricData with payload: ${JSON.stringify(input)}`);
+
   await cloudwatch.putMetricData(input).promise();
-  logger.log('Done');
 }

--- a/lib/pipeline-watcher/watcher.ts
+++ b/lib/pipeline-watcher/watcher.ts
@@ -99,6 +99,7 @@ export class PipelineWatcher extends Construct {
       threshold: 1,
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       evaluationPeriods: 1,
+      // IGNORE missing data, so the alarm stays in its current state, until the next data point.
       treatMissingData: cloudwatch.TreatMissingData.IGNORE,
     });
   }

--- a/lib/pipeline-watcher/watcher.ts
+++ b/lib/pipeline-watcher/watcher.ts
@@ -1,15 +1,13 @@
-// tslint:disable-next-line: max-line-length
 import * as fs from 'fs';
 import * as path from 'path';
 import {
-  Construct, Resource,
+  Construct,
   aws_cloudwatch as cloudwatch,
   aws_codepipeline as cpipeline,
   aws_events as events,
   aws_events_targets as events_targets,
   aws_iam as iam,
   aws_lambda as lambda,
-  aws_logs as logs,
 } from 'monocdk';
 
 export interface PipelineWatcherProps {
@@ -44,44 +42,39 @@ export class PipelineWatcher extends Construct {
   constructor(parent: Construct, name: string, props: PipelineWatcherProps) {
     super(parent, name);
 
+    const metricNamespace = 'CDK/Delivlib';
+    const metricName = 'PipelineActionFailures';
+
     const pipelineWatcher = new lambda.Function(this, 'Poller', {
       handler: 'index.handler',
-      runtime: lambda.Runtime.NODEJS_10_X,
-      code: lambda.Code.inline(fs.readFileSync(path.join(__dirname, 'watcher-handler.js')).toString('utf8')),
+      runtime: lambda.Runtime.NODEJS_12_X,
+      code: lambda.Code.fromInline(fs.readFileSync(path.join(__dirname, 'watcher-handler.js')).toString('utf8')),
       environment: {
-        PIPELINE_NAME: props.pipeline.pipelineName,
+        METRIC_NAMESPACE: metricNamespace,
+        METRIC_NAME: metricName,
       },
     });
 
-    // See https://github.com/awslabs/aws-cdk/issues/1340 for exposing grants on the pipeline.
     pipelineWatcher.addToRolePolicy(new iam.PolicyStatement({
-      resources: [props.pipeline.pipelineArn],
-      actions: ['codepipeline:GetPipelineState'],
+      resources: ['*'],
+      actions: ['cloudwatch:PutMetricData'],
+      conditions: {
+        StringEquals: {
+          'cloudwatch:namespace': metricNamespace,
+        },
+      },
     }));
 
-    // ex: arn:aws:logs:us-east-1:123456789012:log-group:my-log-group
-    const logGroup = new logs.LogGroup(this, 'Logs', {
-      logGroupName: `/aws/lambda/${pipelineWatcher.functionName}`,
-    });
-
-    const trigger = new events.Rule(this, 'Trigger', {
-      schedule: events.Schedule.expression('rate(1 minute)'),
+    new events.Rule(this, 'Trigger', {
+      eventPattern: {
+        source: ['aws.codepipeline'],
+        resources: [props.pipeline.pipelineArn],
+        detailType: ['CodePipeline Action Execution State Change'],
+        detail: {
+          state: ['FAILED', 'SUCCEEDED'],
+        },
+      },
       targets: [new events_targets.LambdaFunction(pipelineWatcher)],
-    });
-
-    const logGroupResource = logGroup.node.findChild('Resource') as Resource;
-    const triggerResource = trigger.node.findChild('Resource') as Resource;
-    triggerResource.node.addDependency(logGroupResource);
-
-    const metricNamespace = 'CDK/Delivlib';
-    const metricName = `${props.pipeline.pipelineName}_FailedStages`;
-
-    new logs.MetricFilter(this, 'MetricFilter', {
-      filterPattern: logs.FilterPattern.exists('$.failedCount'),
-      metricNamespace,
-      metricName,
-      metricValue: '$.failedCount',
-      logGroup,
     });
 
     this.alarm = new cloudwatch.Alarm(this, 'Alarm', {
@@ -90,11 +83,14 @@ export class PipelineWatcher extends Construct {
         metricName,
         namespace: metricNamespace,
         statistic: cloudwatch.Statistic.MAXIMUM,
+        dimensions: {
+          Pipeline: props.pipeline.pipelineName,
+        },
       }),
       threshold: 1,
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       evaluationPeriods: 1,
-      treatMissingData: cloudwatch.TreatMissingData.IGNORE, // We expect a steady stream of data points
+      treatMissingData: cloudwatch.TreatMissingData.IGNORE,
     });
   }
 }

--- a/lib/pipeline-watcher/watcher.ts
+++ b/lib/pipeline-watcher/watcher.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as path from 'path';
 import {
   Construct,
@@ -48,7 +47,7 @@ export class PipelineWatcher extends Construct {
     const pipelineWatcher = new lambda.Function(this, 'Poller', {
       handler: 'index.handler',
       runtime: lambda.Runtime.NODEJS_12_X,
-      code: lambda.Code.fromInline(fs.readFileSync(path.join(__dirname, 'watcher-handler.js')).toString('utf8')),
+      code: lambda.Code.fromAsset(path.join(__dirname, 'handler')),
       environment: {
         METRIC_NAMESPACE: metricNamespace,
         METRIC_NAME: metricName,

--- a/lib/pipeline-watcher/watcher.ts
+++ b/lib/pipeline-watcher/watcher.ts
@@ -42,10 +42,10 @@ export class PipelineWatcher extends Construct {
     super(parent, name);
 
     const metricNamespace = 'CDK/Delivlib';
-    const metricName = 'PipelineActionFailures';
+    const metricName = 'Failures';
 
     const pipelineWatcher = new lambda.Function(this, 'Poller', {
-      handler: 'index.handler',
+      handler: 'watcher-handler.handler',
       runtime: lambda.Runtime.NODEJS_12_X,
       code: lambda.Code.fromAsset(path.join(__dirname, 'handler')),
       environment: {
@@ -68,7 +68,10 @@ export class PipelineWatcher extends Construct {
       eventPattern: {
         source: ['aws.codepipeline'],
         resources: [props.pipeline.pipelineArn],
-        detailType: ['CodePipeline Action Execution State Change'],
+        detailType: [
+          'CodePipeline Action Execution State Change',
+          'CodePipeline Pipeline Execution State Change',
+        ],
         detail: {
           state: ['FAILED', 'SUCCEEDED'],
         },

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -26,6 +26,8 @@ import { determineRunOrder } from './util';
 
 const PUBLISH_STAGE_NAME = 'Publish';
 const TEST_STAGE_NAME = 'Test';
+const METRIC_NAMESPACE = 'CDK/Delivlib';
+const FAILURE_METRIC_NAME = 'Failures';
 
 export interface PipelineProps {
   /**
@@ -457,9 +459,26 @@ export class Pipeline extends Construct {
     });
   }
 
+  /**
+   * The metrics that tracks pipeline failures.
+   */
+  public metricFailures(options: cloudwatch.MetricOptions): cloudwatch.IMetric {
+    return new cloudwatch.Metric({
+      namespace: METRIC_NAMESPACE,
+      metricName: FAILURE_METRIC_NAME,
+      dimensions: {
+        Pipeline: this.pipeline.pipelineName,
+      },
+      statistic: 'Sum',
+      ...options,
+    });
+  }
+
   private addFailureAlarm(title?: string): cloudwatch.Alarm {
     return new PipelineWatcher(this, 'PipelineWatcher', {
       pipeline: this.pipeline,
+      metricNamespace: METRIC_NAMESPACE,
+      failureMetricName: FAILURE_METRIC_NAME,
       title,
     }).alarm;
   }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@monocdk-experiment/assert": "1.87.1",
+    "@types/aws-lambda": "^8.10.3",
     "@types/jest": "^26.0.20",
     "@types/node": "^10.17.51",
     "@typescript-eslint/eslint-plugin": "^4.8.1",

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -1313,15 +1313,12 @@ Resources:
     Properties:
       PolicyDocument:
         Statement:
-          - Action: codepipeline:GetPipelineState
+          - Action: cloudwatch:PutMetricData
+            Condition:
+              StringEquals:
+                cloudwatch:namespace: CDK/Delivlib
             Effect: Allow
-            Resource:
-              Fn::Join:
-                - ""
-                - - "arn:"
-                  - Ref: AWS::Partition
-                  - ":codepipeline:us-east-1:712950704752:"
-                  - Ref: CodeCommitPipelineBuildPipeline656B8CCB
+            Resource: "*"
         Version: "2012-10-17"
       PolicyName: CodeCommitPipelinePipelineWatcherPollerServiceRoleDefaultPolicyE2104AD1
       Roles:
@@ -1332,84 +1329,43 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        ZipFile: >-
-          "use strict";
-
-          Object.defineProperty(exports, "__esModule", { value: true });
-
-          exports.handler = exports.logger = exports.codePipeline = void 0;
-
-          const AWS = require("aws-sdk");
-
-          // export for tests
-
-          exports.codePipeline = new AWS.CodePipeline();
-
-          exports.logger = {
-              log: (line) => process.stdout.write(line),
-          };
-
-          /**
-           * Lambda function for checking the stages of a CodePipeline and emitting log
-           * entries with { failedCount = <no. of failed stages> } for async metric
-           * aggregation via metric filters.
-           *
-           * It requires the pipeline's name be set as the 'PIPELINE_NAME' environment variable.
-           */
-          async function handler() {
-              const pipelineName = process.env.PIPELINE_NAME;
-              if (!pipelineName) {
-                  throw new Error("Pipeline name expects environment variable: 'PIPELINE_NAME'");
-              }
-              const state = await exports.codePipeline.getPipelineState({
-                  name: pipelineName,
-              }).promise();
-              let failedCount = 0;
-              if (state.stageStates) {
-                  failedCount = state.stageStates
-                      .filter(stage => stage.latestExecution !== undefined && stage.latestExecution.status === 'Failed')
-                      .length;
-              }
-              exports.logger.log(JSON.stringify({
-                  failedCount,
-              }));
-          }
-
-          exports.handler = handler;
-
-          //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoid2F0Y2hlci1oYW5kbGVyLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsid2F0Y2hlci1oYW5kbGVyLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7OztBQUFBLCtCQUErQjtBQUcvQixtQkFBbUI7QUFDTixRQUFBLFlBQVksR0FBRyxJQUFJLEdBQUcsQ0FBQyxZQUFZLEVBQUUsQ0FBQztBQUN0QyxRQUFBLE1BQU0sR0FBRztJQUNwQixHQUFHLEVBQUUsQ0FBQyxJQUFZLEVBQUUsRUFBRSxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQztDQUNsRCxDQUFDO0FBRUY7Ozs7OztHQU1HO0FBQ0ksS0FBSyxVQUFVLE9BQU87SUFDM0IsTUFBTSxZQUFZLEdBQUcsT0FBTyxDQUFDLEdBQUcsQ0FBQyxhQUFhLENBQUM7SUFDL0MsSUFBSSxDQUFDLFlBQVksRUFBRTtRQUNqQixNQUFNLElBQUksS0FBSyxDQUFDLDZEQUE2RCxDQUFDLENBQUM7S0FDaEY7SUFDRCxNQUFNLEtBQUssR0FBRyxNQUFNLG9CQUFZLENBQUMsZ0JBQWdCLENBQUM7UUFDaEQsSUFBSSxFQUFFLFlBQVk7S0FDbkIsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDO0lBRWIsSUFBSSxXQUFXLEdBQUcsQ0FBQyxDQUFDO0lBQ3BCLElBQUksS0FBSyxDQUFDLFdBQVcsRUFBRTtRQUNyQixXQUFXLEdBQUcsS0FBSyxDQUFDLFdBQVc7YUFDNUIsTUFBTSxDQUFDLEtBQUssQ0FBQyxFQUFFLENBQUMsS0FBSyxDQUFDLGVBQWUsS0FBSyxTQUFTLElBQUksS0FBSyxDQUFDLGVBQWUsQ0FBQyxNQUFNLEtBQUssUUFBUSxDQUFDO2FBQ2pHLE1BQU0sQ0FBQztLQUNYO0lBQ0QsY0FBTSxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDO1FBQ3hCLFdBQVc7S0FDWixDQUFDLENBQUMsQ0FBQztBQUNOLENBQUM7QUFsQkQsMEJBa0JDIn0=
+        S3Bucket: cdk-hnb659fds-assets-712950704752-us-east-1
+        S3Key: 077dea6c9f77124778ba0adb7d6d1033dd99be515bf0395ba94cb9734c71eff7.zip
       Role:
         Fn::GetAtt:
           - CodeCommitPipelinePipelineWatcherPollerServiceRole0A1D8005
           - Arn
       Environment:
         Variables:
-          PIPELINE_NAME:
-            Ref: CodeCommitPipelineBuildPipeline656B8CCB
-      Handler: index.handler
-      Runtime: nodejs10.x
+          METRIC_NAMESPACE: CDK/Delivlib
+          METRIC_NAME: Failures
+      Handler: watcher-handler.handler
+      Runtime: nodejs12.x
     DependsOn:
       - CodeCommitPipelinePipelineWatcherPollerServiceRoleDefaultPolicyE2104AD1
       - CodeCommitPipelinePipelineWatcherPollerServiceRole0A1D8005
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/PipelineWatcher/Poller/Resource
-  CodeCommitPipelinePipelineWatcherLogs5DE54482:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName:
-        Fn::Join:
-          - ""
-          - - /aws/lambda/
-            - Ref: CodeCommitPipelinePipelineWatcherPoller5C65ACDE
-      RetentionInDays: 731
-    UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
-    Metadata:
-      aws:cdk:path: delivlib-test/CodeCommitPipeline/PipelineWatcher/Logs/Resource
   CodeCommitPipelinePipelineWatcherTriggerA38A4AD0:
     Type: AWS::Events::Rule
     Properties:
-      ScheduleExpression: rate(1 minute)
+      EventPattern:
+        source:
+          - aws.codepipeline
+        resources:
+          - Fn::Join:
+              - ""
+              - - "arn:"
+                - Ref: AWS::Partition
+                - ":codepipeline:us-east-1:712950704752:"
+                - Ref: CodeCommitPipelineBuildPipeline656B8CCB
+        detail-type:
+          - CodePipeline Action Execution State Change
+          - CodePipeline Pipeline Execution State Change
+        detail:
+          state:
+            - FAILED
+            - SUCCEEDED
       State: ENABLED
       Targets:
         - Arn:
@@ -1417,8 +1373,6 @@ Resources:
               - CodeCommitPipelinePipelineWatcherPoller5C65ACDE
               - Arn
           Id: Target0
-    DependsOn:
-      - CodeCommitPipelinePipelineWatcherLogs5DE54482
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/PipelineWatcher/Trigger/Resource
   CodeCommitPipelinePipelineWatcherTriggerAllowEventRuledelivlibtestCodeCommitPipelinePipelineWatcherTrigger0F55C264308E3E05:
@@ -1436,33 +1390,17 @@ Resources:
           - Arn
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/PipelineWatcher/Trigger/AllowEventRuledelivlibtestCodeCommitPipelinePipelineWatcherTrigger0F55C264
-  CodeCommitPipelinePipelineWatcherMetricFilter1D1A0C4D:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      FilterPattern: '{ $.failedCount = "*" }'
-      LogGroupName:
-        Ref: CodeCommitPipelinePipelineWatcherLogs5DE54482
-      MetricTransformations:
-        - MetricName:
-            Fn::Join:
-              - ""
-              - - Ref: CodeCommitPipelineBuildPipeline656B8CCB
-                - _FailedStages
-          MetricNamespace: CDK/Delivlib
-          MetricValue: $.failedCount
-    Metadata:
-      aws:cdk:path: delivlib-test/CodeCommitPipeline/PipelineWatcher/MetricFilter/Resource
   CodeCommitPipelinePipelineWatcherAlarm73779F48:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
       AlarmDescription: Pipeline aws-delivlib test pipeline has failed stages
-      MetricName:
-        Fn::Join:
-          - ""
-          - - Ref: CodeCommitPipelineBuildPipeline656B8CCB
-            - _FailedStages
+      Dimensions:
+        - Name: Pipeline
+          Value:
+            Ref: CodeCommitPipelineBuildPipeline656B8CCB
+      MetricName: Failures
       Namespace: CDK/Delivlib
       Period: 300
       Statistic: Maximum

--- a/test/watcher-handler.test.ts
+++ b/test/watcher-handler.test.ts
@@ -1,10 +1,167 @@
-import { CodePipelineActionStateChangeEvent, cloudwatch, handler } from '../lib/pipeline-watcher/handler/watcher-handler';
+import { LambdaActionStateChangeEvent, LambdaExecutionStateChangeEvent, cloudwatch, handler } from '../lib/pipeline-watcher/handler/watcher-handler';
 
 cloudwatch.putMetricData = jest.fn();
 
-function event(
+describe('watcher-handler', () => {
+  beforeEach(() => {
+    process.env.METRIC_NAME = 'metricName';
+    process.env.METRIC_NAMESPACE = 'metricNamespace';
+  });
+
+  test('throws an error if PutMetricData fails', async () => {
+    expect.assertions(1);
+    cloudwatch.putMetricData = jest.fn(_request => {
+      return {
+        promise: () => new Promise((_, reject) => reject(new Error('fail'))),
+      };
+    }) as any;
+    try {
+      await handler(actionExecutionEvent());
+    } catch (err) {
+      expect(err.message).toEqual('fail');
+    }
+  });
+
+  test('throws an error if METRIC_NAME is undefined', async () => {
+    delete process.env.METRIC_NAME;
+    expect.assertions(1);
+    try {
+      await handler(actionExecutionEvent());
+    } catch (err) {
+      expect(err.message).toMatch(/environment variables must be set/);
+    }
+  });
+
+  test('throws an error if METRIC_NAMESPACE is undefined', async () => {
+    delete process.env.METRIC_NAMESPACE;
+    expect.assertions(1);
+    try {
+      await handler(actionExecutionEvent());
+    } catch (err) {
+      expect(err.message).toMatch(/environment variables must be set/);
+    }
+  });
+
+  describe('Action Execution State Change', () => {
+    test('throws an error if state is not SUCCEEDED or FAILED', async () => {
+      expect.assertions(1);
+      try {
+        await handler(actionExecutionEvent('STARTED'));
+      } catch (err) {
+        expect(err.message).toMatch(/Unsupported/);
+      }
+    });
+
+    test('reports FAILED state metrics', async () => {
+      expect.assertions(1);
+      cloudwatch.putMetricData = jest.fn(request => {
+        expect(request).toEqual({
+          Namespace: 'metricNamespace',
+          MetricData: [
+            {
+              MetricName: 'metricName',
+              Value: 1,
+              Dimensions: [
+                { Name: 'Pipeline', Value: 'some-pipeline' },
+                { Name: 'Action', Value: 'some-action' },
+              ],
+              Timestamp: new Date(1611751440000),
+            },
+          ],
+        });
+        return {
+          promise: () => new Promise((resolve, _) => resolve({})),
+        };
+      }) as any;
+      await handler(actionExecutionEvent('FAILED'));
+    });
+
+    test('reports SUCCEEDED state metrics', async () => {
+      expect.assertions(1);
+      cloudwatch.putMetricData = jest.fn(request => {
+        expect(request).toEqual({
+          Namespace: 'metricNamespace',
+          MetricData: [
+            {
+              MetricName: 'metricName',
+              Value: 0,
+              Dimensions: [
+                { Name: 'Pipeline', Value: 'some-pipeline' },
+                { Name: 'Action', Value: 'some-action' },
+              ],
+              Timestamp: new Date(1611751440000),
+            },
+          ],
+        });
+        return {
+          promise: () => new Promise((resolve, _) => resolve({})),
+        };
+      }) as any;
+      await handler(actionExecutionEvent('SUCCEEDED'));
+    });
+  });
+
+  describe('Pipeline Execution State Change', () => {
+    test('throws an error if state is not SUCCEEDED or FAILED', async () => {
+      expect.assertions(1);
+      try {
+        await handler(pipelineExecutionEvent('STARTED'));
+      } catch (err) {
+        expect(err.message).toMatch(/Unsupported/);
+      }
+    });
+
+    test('reports FAILED state metrics', async () => {
+      expect.assertions(1);
+      cloudwatch.putMetricData = jest.fn(request => {
+        expect(request).toEqual({
+          Namespace: 'metricNamespace',
+          MetricData: [
+            {
+              MetricName: 'metricName',
+              Value: 1,
+              Dimensions: [
+                { Name: 'Pipeline', Value: 'some-pipeline' },
+              ],
+              Timestamp: new Date(1611751440000),
+            },
+          ],
+        });
+        return {
+          promise: () => new Promise((resolve, _) => resolve({})),
+        };
+      }) as any;
+      await handler(pipelineExecutionEvent('FAILED'));
+    });
+
+    test('reports SUCCEEDED state metrics', async () => {
+      expect.assertions(1);
+      cloudwatch.putMetricData = jest.fn(request => {
+        expect(request).toEqual({
+          Namespace: 'metricNamespace',
+          MetricData: [
+            {
+              MetricName: 'metricName',
+              Value: 0,
+              Dimensions: [
+                { Name: 'Pipeline', Value: 'some-pipeline' },
+              ],
+              Timestamp: new Date(1611751440000),
+            },
+          ],
+        });
+        return {
+          promise: () => new Promise((resolve, _) => resolve({})),
+        };
+      }) as any;
+      await handler(pipelineExecutionEvent('SUCCEEDED'));
+    });
+  });
+});
+
+function actionExecutionEvent(
   state: 'STARTED' | 'CANCELED' | 'FAILED' | 'SUCCEEDED' = 'SUCCEEDED',
-): AWSLambda.EventBridgeEvent<'CodePipeline Action Execution State Change', CodePipelineActionStateChangeEvent> {
+): LambdaActionStateChangeEvent {
   return {
     'id': 'some-id',
     'version': '1',
@@ -22,112 +179,21 @@ function event(
   };
 }
 
-describe('watcher-handler', () => {
-  beforeEach(() => {
-    process.env.METRIC_NAME = 'metricName';
-    process.env.METRIC_NAMESPACE = 'metricNamespace';
-  });
-
-  test('throws an error if PutMetricData fails', async () => {
-    expect.assertions(1);
-    cloudwatch.putMetricData = jest.fn(_request => {
-      return {
-        promise: () => new Promise((_, reject) => reject(new Error('fail'))),
-      };
-    }) as any;
-    try {
-      await handler(event());
-    } catch (err) {
-      expect(err.message).toEqual('fail');
-    }
-  });
-
-  test('throws an error if METRIC_NAME is undefined', async () => {
-    delete process.env.METRIC_NAME;
-    expect.assertions(1);
-    try {
-      await handler(event());
-    } catch (err) {
-      expect(err.message).toMatch(/environment variables must be set/);
-    }
-  });
-
-  test('throws an error if METRIC_NAMESPACE is undefined', async () => {
-    delete process.env.METRIC_NAMESPACE;
-    expect.assertions(1);
-    try {
-      await handler(event());
-    } catch (err) {
-      expect(err.message).toMatch(/environment variables must be set/);
-    }
-  });
-
-  test('throws an error if state is not SUCCEEDED or FAILED', async () => {
-    expect.assertions(1);
-    try {
-      await handler(event('STARTED'));
-    } catch (err) {
-      expect(err.message).toMatch(/Unsupported/);
-    }
-  });
-
-  test('reports FAILED state metrics', async () => {
-    expect.assertions(1);
-    cloudwatch.putMetricData = jest.fn(request => {
-      expect(request).toEqual({
-        Namespace: 'metricNamespace',
-        MetricData: [
-          {
-            MetricName: 'metricName',
-            Value: 1,
-            Dimensions: [
-              {
-                Name: 'Pipeline',
-                Value: 'some-pipeline',
-              },
-              {
-                Name: 'Action',
-                Value: 'some-action',
-              },
-            ],
-            Timestamp: new Date(1611751440000),
-          },
-        ],
-      });
-      return {
-        promise: () => new Promise((resolve, _) => resolve({})),
-      };
-    }) as any;
-    await handler(event('FAILED'));
-  });
-
-  test('reports SUCCEEDED state metrics', async () => {
-    expect.assertions(1);
-    cloudwatch.putMetricData = jest.fn(request => {
-      expect(request).toEqual({
-        Namespace: 'metricNamespace',
-        MetricData: [
-          {
-            MetricName: 'metricName',
-            Value: 0,
-            Dimensions: [
-              {
-                Name: 'Pipeline',
-                Value: 'some-pipeline',
-              },
-              {
-                Name: 'Action',
-                Value: 'some-action',
-              },
-            ],
-            Timestamp: new Date(1611751440000),
-          },
-        ],
-      });
-      return {
-        promise: () => new Promise((resolve, _) => resolve({})),
-      };
-    }) as any;
-    await handler(event('SUCCEEDED'));
-  });
-});
+function pipelineExecutionEvent(
+  state: 'STARTED' | 'CANCELED' | 'FAILED' | 'SUCCEEDED' = 'SUCCEEDED',
+): LambdaExecutionStateChangeEvent {
+  return {
+    'id': 'some-id',
+    'version': '1',
+    'account': '0123456789',
+    'resources': ['some-resource'],
+    'time': '2021-01-27T12:44:00Z',
+    'detail-type': 'CodePipeline Pipeline Execution State Change',
+    'region': 'us-east-1',
+    'source': 'aws.codepipeline',
+    'detail': {
+      pipeline: 'some-pipeline',
+      state,
+    },
+  };
+}

--- a/test/watcher-handler.test.ts
+++ b/test/watcher-handler.test.ts
@@ -1,113 +1,133 @@
-import { codePipeline, handler, logger } from '../lib/pipeline-watcher/watcher-handler';
+import { CodePipelineActionStateChangeEvent, cloudwatch, handler } from '../lib/pipeline-watcher/handler/watcher-handler';
 
-codePipeline.getPipelineState = jest.fn();
+cloudwatch.putMetricData = jest.fn();
 
-test('handler should propagate error if GetPipelineState fails', async () => {
-  process.env.PIPELINE_NAME = 'name';
-  expect.assertions(2);
-  codePipeline.getPipelineState = jest.fn(request => {
-    expect(request).toEqual({ name: 'name' });
-    return {
-      promise: () => new Promise((_, reject) => reject(new Error('fail'))),
-    };
-  }) as any;
-  try {
-    await handler();
-  } catch (err) {
-    expect(err.message).toEqual('fail');
-  }
-});
-
-test('handler should throw error if process.env.PIPELINE_NAME is undefined', async () => {
-  delete process.env.PIPELINE_NAME;
-  expect.assertions(1);
-  try {
-    await handler();
-  } catch (err) {
-    expect(err.message).toEqual("Pipeline name expects environment variable: 'PIPELINE_NAME'");
-  }
-});
-
-// prepare log with a new mock, set the name env variable and mock the getPipelineState fn.
-function mock(response: any) {
-  logger.log = jest.fn();
-  process.env.PIPELINE_NAME = 'name';
-  codePipeline.getPipelineState = jest.fn(request => {
-    expect(request && request.name).toEqual(process.env.PIPELINE_NAME);
-    return {
-      promise: () => new Promise((resolve) => resolve(response)),
-    };
-  }) as any;
+function event(
+  state: 'STARTED' | 'CANCELED' | 'FAILED' | 'SUCCEEDED' = 'SUCCEEDED',
+): AWSLambda.EventBridgeEvent<'CodePipeline Action Execution State Change', CodePipelineActionStateChangeEvent> {
+  return {
+    'id': 'some-id',
+    'version': '1',
+    'account': '0123456789',
+    'resources': ['some-resource'],
+    'time': '2021-01-27T12:44:00Z',
+    'detail-type': 'CodePipeline Action Execution State Change',
+    'region': 'us-east-1',
+    'source': 'aws.codepipeline',
+    'detail': {
+      action: 'some-action',
+      pipeline: 'some-pipeline',
+      state,
+    },
+  };
 }
 
-test('handler should log {failCount: 0} if pipeline.stageStates is undefined', async () => {
-  mock({});
-  await handler();
-  expect(logger.log).toBeCalledTimes(1);
-  expect(logger.log).toBeCalledWith(JSON.stringify({ failedCount: 0 }));
-});
-
-test('handler should log {failCount: 0} if pipeline.stageStates is empty', async () => {
-  mock({ stageStates: [] });
-  await handler();
-  expect(logger.log).toBeCalledTimes(1);
-  expect(logger.log).toBeCalledWith(JSON.stringify({ failedCount: 0 }));
-});
-
-test('handler should log {failCount: 0} if pipeline.stageStates[:0].latestExecution are undefined', async () => {
-  mock({
-    stageStates: [{
-      latestExecution: undefined,
-    }],
+describe('watcher-handler', () => {
+  beforeEach(() => {
+    process.env.METRIC_NAME = 'metricName';
+    process.env.METRIC_NAMESPACE = 'metricNamespace';
   });
-  await handler();
-  expect(logger.log).toBeCalledTimes(1);
-  expect(logger.log).toBeCalledWith(JSON.stringify({ failedCount: 0 }));
-});
 
-test('handler should log {failCount: 0} if none of pipeline.stageStates[:0].latestExecution.status are Failed', async () => {
-  mock({
-    stageStates: [{
-      latestExecution: {
-        status: 'Success',
-      },
-    }],
+  test('throws an error if PutMetricData fails', async () => {
+    expect.assertions(1);
+    cloudwatch.putMetricData = jest.fn(_request => {
+      return {
+        promise: () => new Promise((_, reject) => reject(new Error('fail'))),
+      };
+    }) as any;
+    try {
+      await handler(event());
+    } catch (err) {
+      expect(err.message).toEqual('fail');
+    }
   });
-  await handler();
-  expect(logger.log).toBeCalledTimes(1);
-  expect(logger.log).toBeCalledWith(JSON.stringify({ failedCount: 0 }));
-});
 
-test('handler should log {failCount: 1} if one of pipeline.stageStates[:0].latestExecution.status is Failed', async () => {
-  mock({
-    stageStates: [{
-      latestExecution: {
-        status: 'Failed',
-      },
-    }],
+  test('throws an error if METRIC_NAME is undefined', async () => {
+    delete process.env.METRIC_NAME;
+    expect.assertions(1);
+    try {
+      await handler(event());
+    } catch (err) {
+      expect(err.message).toMatch(/environment variables must be set/);
+    }
   });
-  await handler();
-  expect(logger.log).toBeCalledTimes(1);
-  expect(logger.log).toBeCalledWith(JSON.stringify({ failedCount: 1 }));
-});
 
-test('handler should log {failCount: 2} for 2 "Failed" and 1 "Success" pipeline.stageStates[:0].latestExecution.status values', async () => {
-  mock({
-    stageStates: [{
-      latestExecution: {
-        status: 'Failed',
-      },
-    }, {
-      latestExecution: {
-        status: 'Sucess',
-      },
-    }, {
-      latestExecution: {
-        status: 'Failed',
-      },
-    }],
+  test('throws an error if METRIC_NAMESPACE is undefined', async () => {
+    delete process.env.METRIC_NAMESPACE;
+    expect.assertions(1);
+    try {
+      await handler(event());
+    } catch (err) {
+      expect(err.message).toMatch(/environment variables must be set/);
+    }
   });
-  await handler();
-  expect(logger.log).toBeCalledTimes(1);
-  expect(logger.log).toBeCalledWith(JSON.stringify({ failedCount: 2 }));
+
+  test('throws an error if state is not SUCCEEDED or FAILED', async () => {
+    expect.assertions(1);
+    try {
+      await handler(event('STARTED'));
+    } catch (err) {
+      expect(err.message).toMatch(/Unsupported/);
+    }
+  });
+
+  test('reports FAILED state metrics', async () => {
+    expect.assertions(1);
+    cloudwatch.putMetricData = jest.fn(request => {
+      expect(request).toEqual({
+        Namespace: 'metricNamespace',
+        MetricData: [
+          {
+            MetricName: 'metricName',
+            Value: 1,
+            Dimensions: [
+              {
+                Name: 'Pipeline',
+                Value: 'some-pipeline',
+              },
+              {
+                Name: 'Action',
+                Value: 'some-action',
+              },
+            ],
+            Timestamp: new Date(1611751440000),
+          },
+        ],
+      });
+      return {
+        promise: () => new Promise((resolve, _) => resolve({})),
+      };
+    }) as any;
+    await handler(event('FAILED'));
+  });
+
+  test('reports SUCCEEDED state metrics', async () => {
+    expect.assertions(1);
+    cloudwatch.putMetricData = jest.fn(request => {
+      expect(request).toEqual({
+        Namespace: 'metricNamespace',
+        MetricData: [
+          {
+            MetricName: 'metricName',
+            Value: 0,
+            Dimensions: [
+              {
+                Name: 'Pipeline',
+                Value: 'some-pipeline',
+              },
+              {
+                Name: 'Action',
+                Value: 'some-action',
+              },
+            ],
+            Timestamp: new Date(1611751440000),
+          },
+        ],
+      });
+      return {
+        promise: () => new Promise((resolve, _) => resolve({})),
+      };
+    }) as any;
+    await handler(event('SUCCEEDED'));
+  });
 });

--- a/test/watcher.test.ts
+++ b/test/watcher.test.ts
@@ -3,11 +3,16 @@ import { Stack } from 'monocdk';
 import { Pipeline } from 'monocdk/aws-codepipeline';
 import { PipelineWatcher } from '../lib/pipeline-watcher';
 
+const props = {
+  metricNamespace: 'Namespace',
+  failureMetricName: 'FailureMetricName',
+};
+
 describe('PipelineWatcher', () => {
   test('default', () => {
     const stack = new Stack();
     const pipeline = Pipeline.fromPipelineArn(stack, 'Pipeline', 'arn:aws:codepipeline:us-east-1:012345789:MyPipeline');
-    new PipelineWatcher(stack, 'Watcher', { pipeline });
+    new PipelineWatcher(stack, 'Watcher', { pipeline, ...props });
 
     expect(stack).toHaveResource('AWS::Events::Rule');
     expect(stack).toHaveResource('AWS::Lambda::Function');
@@ -21,8 +26,8 @@ describe('PipelineWatcher', () => {
           Value: 'MyPipeline',
         },
       ],
-      MetricName: 'Failures',
-      Namespace: 'CDK/Delivlib',
+      MetricName: 'FailureMetricName',
+      Namespace: 'Namespace',
       Period: 300,
       Statistic: 'Maximum',
       Threshold: 1,
@@ -33,7 +38,7 @@ describe('PipelineWatcher', () => {
   test('title option is correctly handled', () => {
     const stack = new Stack();
     const pipeline = Pipeline.fromPipelineArn(stack, 'Pipeline', 'arn:aws:codepipeline:us-east-1:012345789:MyPipeline');
-    new PipelineWatcher(stack, 'Watcher', { pipeline, title: 'MyTitle' });
+    new PipelineWatcher(stack, 'Watcher', { pipeline, title: 'MyTitle', ...props });
 
     expect(stack).toHaveResource('AWS::CloudWatch::Alarm', {
       AlarmDescription: 'Pipeline MyTitle has failed stages',
@@ -43,7 +48,7 @@ describe('PipelineWatcher', () => {
   test('lambda function has the expected policy', () => {
     const stack = new Stack();
     const pipeline = Pipeline.fromPipelineArn(stack, 'Pipeline', 'arn:aws:codepipeline:us-east-1:012345789:MyPipeline');
-    new PipelineWatcher(stack, 'Watcher', { pipeline });
+    new PipelineWatcher(stack, 'Watcher', { pipeline, ...props });
 
     expect(stack).toHaveResourceLike('AWS::IAM::Policy', {
       PolicyDocument: {
@@ -52,7 +57,7 @@ describe('PipelineWatcher', () => {
             Action: 'cloudwatch:PutMetricData',
             Condition: {
               StringEquals: {
-                'cloudwatch:namespace': 'CDK/Delivlib',
+                'cloudwatch:namespace': 'Namespace',
               },
             },
             Effect: 'Allow',

--- a/test/watcher.test.ts
+++ b/test/watcher.test.ts
@@ -1,0 +1,70 @@
+import '@monocdk-experiment/assert/jest';
+import { Stack } from 'monocdk';
+import { Pipeline } from 'monocdk/aws-codepipeline';
+import { PipelineWatcher } from '../lib/pipeline-watcher';
+
+describe('PipelineWatcher', () => {
+  test('default', () => {
+    const stack = new Stack();
+    const pipeline = Pipeline.fromPipelineArn(stack, 'Pipeline', 'arn:aws:codepipeline:us-east-1:012345789:MyPipeline');
+    new PipelineWatcher(stack, 'Watcher', { pipeline });
+
+    expect(stack).toHaveResource('AWS::Events::Rule');
+    expect(stack).toHaveResource('AWS::Lambda::Function');
+    expect(stack).toHaveResource('AWS::CloudWatch::Alarm', {
+      ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+      EvaluationPeriods: 1,
+      AlarmDescription: 'Pipeline MyPipeline has failed stages',
+      Dimensions: [
+        {
+          Name: 'Pipeline',
+          Value: 'MyPipeline',
+        },
+      ],
+      MetricName: 'Failures',
+      Namespace: 'CDK/Delivlib',
+      Period: 300,
+      Statistic: 'Maximum',
+      Threshold: 1,
+      TreatMissingData: 'ignore',
+    });
+  });
+
+  test('title option is correctly handled', () => {
+    const stack = new Stack();
+    const pipeline = Pipeline.fromPipelineArn(stack, 'Pipeline', 'arn:aws:codepipeline:us-east-1:012345789:MyPipeline');
+    new PipelineWatcher(stack, 'Watcher', { pipeline, title: 'MyTitle' });
+
+    expect(stack).toHaveResource('AWS::CloudWatch::Alarm', {
+      AlarmDescription: 'Pipeline MyTitle has failed stages',
+    });
+  });
+
+  test('lambda function has the expected policy', () => {
+    const stack = new Stack();
+    const pipeline = Pipeline.fromPipelineArn(stack, 'Pipeline', 'arn:aws:codepipeline:us-east-1:012345789:MyPipeline');
+    new PipelineWatcher(stack, 'Watcher', { pipeline });
+
+    expect(stack).toHaveResourceLike('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 'cloudwatch:PutMetricData',
+            Condition: {
+              StringEquals: {
+                'cloudwatch:namespace': 'CDK/Delivlib',
+              },
+            },
+            Effect: 'Allow',
+            Resource: '*',
+          },
+        ],
+      },
+      Roles: [
+        {
+          Ref: 'WatcherPollerServiceRole04A8CDED',
+        },
+      ],
+    });
+  });
+});

--- a/test/watcher.test.ts
+++ b/test/watcher.test.ts
@@ -31,7 +31,6 @@ describe('PipelineWatcher', () => {
       Period: 300,
       Statistic: 'Maximum',
       Threshold: 1,
-      TreatMissingData: 'ignore',
     });
   });
 
@@ -70,6 +69,16 @@ describe('PipelineWatcher', () => {
           Ref: 'WatcherPollerServiceRole04A8CDED',
         },
       ],
+    });
+  });
+
+  test('missing data should be treated as ignore', () => {
+    const stack = new Stack();
+    const pipeline = Pipeline.fromPipelineArn(stack, 'Pipeline', 'arn:aws:codepipeline:us-east-1:012345789:MyPipeline');
+    new PipelineWatcher(stack, 'Watcher', { pipeline, ...props });
+
+    expect(stack).toHaveResource('AWS::CloudWatch::Alarm', {
+      TreatMissingData: 'ignore',
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -580,6 +580,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/aws-lambda@^8.10.3":
+  version "8.10.71"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.71.tgz#ab3084038411ce42f63b975e67aafb163f3aa353"
+  integrity sha512-l0Lag6qq06AlKllprAJ3pbgVUbXCjRGRb7VpHow8IMn2BMHTPR0t5OD97/w8CR1+wA5XZuWQoXLjYvdlk2kQrQ==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.9"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.9.tgz#77e59d438522a6fb898fa43dc3455c6e72f3963d"


### PR DESCRIPTION
Currently, metrics are emitted for each pipeline failure as
`<pipelineName>_FailedStages`. This metric is emitted per pipeline once
per minute depending on the state of the pipeline at the time.

This means that if a pipeline is in failed state for 20 minutes, there
will be 20 non-zero datapoints for this metric.
This is not very useful in aggregating failure over time and summarizing
them over hours, days or weeks.

This commit changes the approach entirely. Instead of running the
metrics on a fixed schedule, it reacts to CodePipeline events and emits
the appropriate metric. This should result in one non-zero data point
per failure.

This commit also changes the metric name and includes dimensions for
better querying. It now emits a single metric `PipelineActionFailures`
under the namespace `CDK/Delivlib`. This metric has two dimensions -
`Pipeline` with the name of the pipeline and `Action` with the name of
the Action.
This lets higher resolution on the metrics to identify specific Actions
that are failing more often, while letting aggregated metrics.

BREAKING CHANGE: delivlib `Pipeline` construct no longer produces
the `<pipelineName>_FailedStages` metric. It instead produces the
metric `PipelineActionFailures` with the pipeline name as a dimension.

-----

See https://github.com/awslabs/aws-delivlib/pull/696#issuecomment-770991135
for additional testing

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
