### PR TITLE
fix(pypi): cryptography >= 3.4 is not supported by older pip

### DIFF
--- a/lib/publishing/pypi/publish.sh
+++ b/lib/publishing/pypi/publish.sh
@@ -6,6 +6,10 @@ credentials=$(aws secretsmanager get-secret-value --secret-id ${PYPI_CREDENTIALS
 export TWINE_USERNAME=$(python -c "import json; print(json.loads('''${credentials}''')['username'])")
 export TWINE_PASSWORD=$(python -c "import json; print(json.loads('''${credentials}''')['password'])")
 
+# make sure we use the latest pip
+# see https://cryptography.io/en/latest/faq.html#installing-cryptography-fails-with-error-can-not-find-rust-compiler
+pip install --upgrade pip
+
 pip install twine
 
 if [[ "${FOR_REAL:-}" == "true" ]]; then

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -3598,7 +3598,7 @@ Resources:
             Value: cdk-hnb659fds-assets-712950704752-us-east-1
           - Name: SCRIPT_S3_KEY
             Type: PLAINTEXT
-            Value: ce59f620887cda617e5a0b25e86cc026b339d2976b51830b2048fde6567507ca.zip
+            Value: c17f8f9d719e9e4e72c47092e9d9a130a19c607b87d5f5a327b05f38c219c1ca.zip
           - Name: FOR_REAL
             Type: PLAINTEXT
             Value: "true"


### PR DESCRIPTION
`twince`, which is used by the python publisher, has a dependency on the `cryptography` module.
As described in their [changelog], starting version 3.4, they require the latest version of `pip`. Otherwise,
the installer will attempt to compile the module, and the Rust compiler will be required.

This fails in the amazon/aws-sam-cli-build-image-python3.6 image since it has an older version of pip installed.

To fix, simply add an instruction to the dockerfile to upgrade to the latest pip version before installing.

[changelog]: https://cryptography.io/en/3.4/changelog.html#v3-4


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
