### PR TITLE
feat: golang publishing

### DIFF
--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -398,6 +398,9 @@ export class Pipeline extends Construct {
     }), options);
   }
 
+  /**
+   * Publish Golang code from `go` directory in build artifact to a GitHub repository.
+   */
   public publishToGolang(options: publishing.PublishToGolangProps) {
     this.addPublish(new publishing.PublishToGolang(this, 'Golang', {
       dryRun: this.dryRun,

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -398,6 +398,13 @@ export class Pipeline extends Construct {
     }), options);
   }
 
+  public publishToGolang(options: publishing.PublishToGolangProps) {
+    this.addPublish(new publishing.PublishToGolang(this, 'Golang', {
+      dryRun: this.dryRun,
+      ...options,
+    }));
+  }
+
   /**
    * Enables automatic bumps for the source repo.
    * @param options Options for auto bump (see AutoBumpOptions for description of defaults)

--- a/lib/publishing/golang/publish.sh
+++ b/lib/publishing/golang/publish.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+echo ----------------------------------------
+echo "Sources:"
+ls
+echo ----------------------------------------
+
+# Prepare the GitHub token
+token="$(aws secretsmanager get-secret-value --secret-id ${GITHUB_TOKEN_SECRET} --output=text --query=SecretString)"
+export GITHUB_TOKEN="${token}"
+
+if [ ! -d "go" ]; then
+  echo "Skipping go publishing. No 'go' directory in artifact."
+  exit 0
+fi
+
+exec npx -p jsii-release jsii-release-golang go/

--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -33,7 +33,7 @@ export interface ShellableOptions {
    *
    * @default No additional environment variables
    */
-  environment?: { [key: string]: string };
+  environment?: { [key: string]: string | undefined };
 
   /**
    * Environment variables with secrets manager values. The values must be complete Secret Manager ARNs.

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -40,14 +40,16 @@ export function hashFileOrDirectory(fileOrDir: string): string {
   return hash.digest('base64');
 }
 
-export function renderEnvironmentVariables(env?: { [key: string]: string }, type?: cbuild.BuildEnvironmentVariableType) {
+export function renderEnvironmentVariables(env?: { [key: string]: string | undefined }, type?: cbuild.BuildEnvironmentVariableType) {
   if (!env) {
     return undefined;
   }
 
   const out: { [key: string]: cbuild.BuildEnvironmentVariable } = { };
   for (const [key, value] of Object.entries(env)) {
-    out[key] = { value, type };
+    if (value) {
+      out[key] = { value, type };
+    }
   }
   return out;
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -47,7 +47,7 @@ export function renderEnvironmentVariables(env?: { [key: string]: string | undef
 
   const out: { [key: string]: cbuild.BuildEnvironmentVariable } = { };
   for (const [key, value] of Object.entries(env)) {
-    if (value) {
+    if (value !== undefined) {
       out[key] = { value, type };
     }
   }

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -2631,6 +2631,9 @@ Resources:
           - Name: NPM_TOKEN_SECRET
             Type: PLAINTEXT
             Value: arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/npm-OynG62
+          - Name: DISTTAG
+            Type: PLAINTEXT
+            Value: ""
           - Name: ACCESS
             Type: PLAINTEXT
             Value: restricted

--- a/test/expected.yml
+++ b/test/expected.yml
@@ -300,6 +300,28 @@ Resources:
                   - CodeCommitPipelinePyPIRole30E20A9B
                   - Arn
             Resource: "*"
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - CodeCommitPipelineGolangRole46DA8D4C
+                  - Arn
+            Resource: "*"
+          - Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - CodeCommitPipelineGolangRole46DA8D4C
+                  - Arn
+            Resource: "*"
         Version: "2012-10-17"
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete
@@ -448,6 +470,12 @@ Resources:
             Resource:
               Fn::GetAtt:
                 - CodeCommitPipelineBuildPipelinePublishPyPIPublishCodePipelineActionRole05AF99D5
+                - Arn
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - CodeCommitPipelineBuildPipelinePublishGolangPublishCodePipelineActionRole365FF3C7
                 - Arn
         Version: "2012-10-17"
       PolicyName: CodeCommitPipelineBuildPipelineRoleDefaultPolicy94C30F44
@@ -673,6 +701,22 @@ Resources:
               RoleArn:
                 Fn::GetAtt:
                   - CodeCommitPipelineBuildPipelinePublishPyPIPublishCodePipelineActionRole05AF99D5
+                  - Arn
+              RunOrder: 1
+            - ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: "1"
+              Configuration:
+                ProjectName:
+                  Ref: CodeCommitPipelineGolangBDFA17A1
+              InputArtifacts:
+                - Name: Artifact_Build_Build
+              Name: GolangPublish
+              RoleArn:
+                Fn::GetAtt:
+                  - CodeCommitPipelineBuildPipelinePublishGolangPublishCodePipelineActionRole365FF3C7
                   - Arn
               RunOrder: 1
           Name: Publish
@@ -1115,6 +1159,43 @@ Resources:
         - Ref: CodeCommitPipelineBuildPipelinePublishPyPIPublishCodePipelineActionRole05AF99D5
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/BuildPipeline/Publish/PyPIPublish/CodePipelineActionRole/DefaultPolicy/Resource
+  CodeCommitPipelineBuildPipelinePublishGolangPublishCodePipelineActionRole365FF3C7:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - :iam::712950704752:root
+        Version: "2012-10-17"
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/BuildPipeline/Publish/GolangPublish/CodePipelineActionRole/Resource
+  CodeCommitPipelineBuildPipelinePublishGolangPublishCodePipelineActionRoleDefaultPolicyED342278:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - codebuild:BatchGetBuilds
+              - codebuild:StartBuild
+              - codebuild:StopBuild
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - CodeCommitPipelineGolangBDFA17A1
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: CodeCommitPipelineBuildPipelinePublishGolangPublishCodePipelineActionRoleDefaultPolicyED342278
+      Roles:
+        - Ref: CodeCommitPipelineBuildPipelinePublishGolangPublishCodePipelineActionRole365FF3C7
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/BuildPipeline/Publish/GolangPublish/CodePipelineActionRole/DefaultPolicy/Resource
   CodeCommitPipelineBuildProjectRoleC6347B6E:
     Type: AWS::IAM::Role
     Properties:
@@ -2550,9 +2631,6 @@ Resources:
           - Name: NPM_TOKEN_SECRET
             Type: PLAINTEXT
             Value: arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/npm-OynG62
-          - Name: DISTTAG
-            Type: PLAINTEXT
-            Value: ""
           - Name: ACCESS
             Type: PLAINTEXT
             Value: restricted
@@ -3659,6 +3737,198 @@ Resources:
       TreatMissingData: ignore
     Metadata:
       aws:cdk:path: delivlib-test/CodeCommitPipeline/PyPI/Default/Alarm/Resource
+  CodeCommitPipelineGolangRole46DA8D4C:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: "2012-10-17"
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/Golang/Default/Resource/Role/Resource
+  CodeCommitPipelineGolangRoleDefaultPolicy189AF9A0:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - :logs:us-east-1:712950704752:log-group:/aws/codebuild/
+                    - Ref: CodeCommitPipelineGolangBDFA17A1
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - :logs:us-east-1:712950704752:log-group:/aws/codebuild/
+                    - Ref: CodeCommitPipelineGolangBDFA17A1
+                    - :*
+          - Action:
+              - codebuild:CreateReportGroup
+              - codebuild:CreateReport
+              - codebuild:UpdateReport
+              - codebuild:BatchPutTestCases
+              - codebuild:BatchPutCodeCoverages
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - :codebuild:us-east-1:712950704752:report-group/
+                  - Ref: CodeCommitPipelineGolangBDFA17A1
+                  - -*
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - :s3:::cdk-hnb659fds-assets-712950704752-us-east-1
+              - Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - :s3:::cdk-hnb659fds-assets-712950704752-us-east-1/*
+          - Action:
+              - secretsmanager:ListSecrets
+              - secretsmanager:DescribeSecret
+              - secretsmanager:GetSecretValue
+            Effect: Allow
+            Resource: arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - CodeCommitPipelineBuildPipelineArtifactsBucketED2813B3
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - CodeCommitPipelineBuildPipelineArtifactsBucketED2813B3
+                        - Arn
+                    - /*
+          - Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - CodeCommitPipelineBuildPipelineArtifactsBucketEncryptionKey05A62A83
+                - Arn
+          - Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - CodeCommitPipelineBuildPipelineArtifactsBucketEncryptionKey05A62A83
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: CodeCommitPipelineGolangRoleDefaultPolicy189AF9A0
+      Roles:
+        - Ref: CodeCommitPipelineGolangRole46DA8D4C
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/Golang/Default/Resource/Role/DefaultPolicy/Resource
+  CodeCommitPipelineGolangBDFA17A1:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Environment:
+        ComputeType: BUILD_GENERAL1_MEDIUM
+        EnvironmentVariables:
+          - Name: SCRIPT_S3_BUCKET
+            Type: PLAINTEXT
+            Value: cdk-hnb659fds-assets-712950704752-us-east-1
+          - Name: SCRIPT_S3_KEY
+            Type: PLAINTEXT
+            Value: d51656c063a0eef8e6e43eebc868209915793a138eb4a16217cb8d51583f6424.zip
+          - Name: GITHUB_TOKEN_SECRET
+            Type: PLAINTEXT
+            Value: arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW
+          - Name: GIT_BRANCH
+            Type: PLAINTEXT
+            Value: golang
+          - Name: GIT_USER_NAME
+            Type: PLAINTEXT
+            Value: Delivlib Tests
+          - Name: GIT_USER_EMAIL
+            Type: PLAINTEXT
+            Value: aws-cdk-dev+delivlib@amazon.com
+        Image: aws/codebuild/standard:5.0
+        ImagePullCredentialsType: CODEBUILD
+        PrivilegedMode: false
+        Type: LINUX_CONTAINER
+      ServiceRole:
+        Fn::GetAtt:
+          - CodeCommitPipelineGolangRole46DA8D4C
+          - Arn
+      Source:
+        BuildSpec: >-
+          {
+            "version": "0.2",
+            "phases": {
+              "pre_build": {
+                "commands": [
+                  "echo \"Downloading scripts from s3://${SCRIPT_S3_BUCKET}/${SCRIPT_S3_KEY}\"",
+                  "aws s3 cp s3://${SCRIPT_S3_BUCKET}/${SCRIPT_S3_KEY} /tmp",
+                  "mkdir -p /tmp/scriptdir",
+                  "unzip /tmp/$(basename $SCRIPT_S3_KEY) -d /tmp/scriptdir"
+                ]
+              },
+              "build": {
+                "commands": [
+                  "export SCRIPT_DIR=/tmp/scriptdir",
+                  "echo \"Running publish.sh\"",
+                  "/bin/bash /tmp/scriptdir/publish.sh"
+                ]
+              }
+            }
+          }
+        Type: NO_SOURCE
+      EncryptionKey:
+        Fn::GetAtt:
+          - CodeCommitPipelineBuildPipelineArtifactsBucketEncryptionKey05A62A83
+          - Arn
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/Golang/Default/Resource/Resource
+  CodeCommitPipelineGolangAlarmF9F61D0D:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Dimensions:
+        - Name: ProjectName
+          Value:
+            Ref: CodeCommitPipelineGolangBDFA17A1
+      MetricName: FailedBuilds
+      Namespace: AWS/CodeBuild
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: ignore
+    Metadata:
+      aws:cdk:path: delivlib-test/CodeCommitPipeline/Golang/Default/Alarm/Resource
   CodeCommitPipelineAutoBumpAutoPullRequestRoleE7E0E388:
     Type: AWS::IAM::Role
     Properties:

--- a/test/shellable.test.ts
+++ b/test/shellable.test.ts
@@ -200,6 +200,8 @@ test('environment variables', () => {
     entrypoint: 'test.sh',
     environment: {
       ENV_VAR: 'env-var-value',
+      UNDEFINED_VAR: undefined,
+      EMPTY_STRING: '',
     },
     environmentSecrets: {
       ENV_VAR_SECRET: 'arn:test:secretsmanager:region:000000000000:secret:env-var-secret-name-abc123',
@@ -242,6 +244,11 @@ test('environment variables', () => {
           Name: 'ENV_VAR',
           Type: 'PLAINTEXT',
           Value: 'env-var-value',
+        },
+        {
+          Name: 'EMPTY_STRING',
+          Type: 'PLAINTEXT',
+          Value: '',
         },
         {
           Name: 'ENV_VAR_SECRET',

--- a/test/test-stack.ts
+++ b/test/test-stack.ts
@@ -165,6 +165,15 @@ export class TestStack extends Stack {
       loginSecret: { secretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/pypi-tOhH6X' },
     });
 
+    // publish go bindings to awslabs/aws-delivlib-sample under the "golang"
+    // branch (repository is derived from "go.moduleName" in package.json)
+    pipeline.publishToGolang({
+      githubTokenSecret: { secretArn: githubRepo.tokenSecretArn },
+      gitBranch: 'golang',
+      gitUserEmail: 'aws-cdk-dev+delivlib@amazon.com',
+      gitUserName: 'Delivlib Tests',
+    });
+
     //
     // BUMP
 


### PR DESCRIPTION
Add support for publishing golang code from the build artifact (under the `go/` directory) to a GitHub repository.

To add a go publishing step to your pipeline, use `pipeline.publishToGolang()` or create an instance of `PublishToGolang` construct.

See the README of [jsii-release] for more details.

**MISC**: allow `Shellable` environment values to be `undefined`, and then they will not be set.

**TESTING**: updated [awslabs/aws-delivlib-sample](https://github.com/awslabs/aws-delivlib-sample) to include a `go` section in the jsii config and tested that the delivlib test pipeline publishes go bindings to the same repo (under the [golang](https://github.com/awslabs/aws-delivlib-sample/tree/golang) branch).

Resolves aws/jsii#2562

[jsii-release]: https://github.com/aws/jsii-release


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
