### PR TITLE
fix(ecr-mirror): only represent non-`latest` tags in construct IDs

### DIFF
--- a/lib/registry-sync/ecr-mirror.ts
+++ b/lib/registry-sync/ecr-mirror.ts
@@ -194,7 +194,12 @@ export class EcrMirror extends Construct {
     if (this._repos.get(`${repositoryName}:${tag}`)) {
       throw new Error(`Mirror source with repository name [${repositoryName}] and tag [${tag}] already exists.`);
     }
-    this._repos.set(`${repositoryName}:${tag}`, new ecr.Repository(this, `Repo${repositoryName}:${tag}`, {
+
+    // Backwards compatibility: can't have this name contain the tag for backwards compatibility. We assume
+    // the tag was always 'latest' before (which might not have been true but that's the best we can do).
+    const constructId = `Repo${repositoryName}${tag !== 'latest' ? `:${tag}` : ''}`;
+
+    this._repos.set(`${repositoryName}:${tag}`, new ecr.Repository(this, constructId, {
       repositoryName,
     }));
   }

--- a/test/registry-sync/ecr-mirror.test.ts
+++ b/test/registry-sync/ecr-mirror.test.ts
@@ -147,7 +147,7 @@ describe('EcrMirror', () => {
       const repo = registry.ecrRepository('my/docker-image');
       expect(repo).toBeDefined();
       expect(stack.resolve(repo!.repositoryArn)).toEqual({
-        'Fn::GetAtt': ['EcrRegistrySyncRepomydockerimagelatestA86E2755', 'Arn'],
+        'Fn::GetAtt': ['EcrRegistrySyncRepomydockerimageCE3ABCA6', 'Arn'],
       });
     });
 
@@ -235,7 +235,7 @@ describe('EcrMirrorAspect', () => {
                   {
                     'Fn::Split': [
                       ':',
-                      { 'Fn::GetAtt': ['MirrorRepomydockerimagelatestE01D7FA1', 'Arn'] },
+                      { 'Fn::GetAtt': ['MirrorRepomydockerimageE8DCCA4F', 'Arn'] },
                     ],
                   },
                 ],
@@ -247,7 +247,7 @@ describe('EcrMirrorAspect', () => {
                   {
                     'Fn::Split': [
                       ':',
-                      { 'Fn::GetAtt': ['MirrorRepomydockerimagelatestE01D7FA1', 'Arn'] },
+                      { 'Fn::GetAtt': ['MirrorRepomydockerimageE8DCCA4F', 'Arn'] },
                     ],
                   },
                 ],
@@ -255,7 +255,7 @@ describe('EcrMirrorAspect', () => {
               '.',
               { Ref: 'AWS::URLSuffix' },
               '/',
-              { Ref: 'MirrorRepomydockerimagelatestE01D7FA1' },
+              { Ref: 'MirrorRepomydockerimageE8DCCA4F' },
               ':latest',
             ],
           ],


### PR DESCRIPTION
Otherwise, all stack `Export`s change, which is not possible.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
